### PR TITLE
Support configuration key to toggle using IPs or hostnames

### DIFF
--- a/airflow/bin/airflow
+++ b/airflow/bin/airflow
@@ -1,8 +1,29 @@
 #!/usr/bin/env python
 import logging
 import os
+import socket
+import requests
 from airflow import configuration
 from airflow.bin.cli import CLIFactory
+
+def get_private_ip(name=''):
+    r = requests.get("http://169.254.169.254/latest/meta-data/local-ipv4")
+    return str(r.text)
+
+
+def getfqdn(name=''):
+    return get_private_ip()
+
+
+should_patch_socket = False
+try:
+    should_patch_socket = configuration.getboolean('lyft', 'prefer_ip_over_hostname')
+except configuration.AirflowConfigException:
+    pass # Default to False if not configured
+
+if should_patch_socket:
+    logging.info("Using IP addresses instead of hostnames.")
+    socket.gethostname = socket.getfqdn = getfqdn
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
# Background

We're patching the socket library in order to use IP addresses instead of hostnames, because Lyft hostnames are special and don't actually resolve. (See https://github.com/lyft/etl/pull/5560 for context) `service_venv` sets the \$PATH such that `/usr/local/lib/service_venv/bin/` takes precedence over `srv/service/current/bin/`, so it's not enough to simply put a patched version of `airflow` in the ETL repository.

We're ensuring that our patched version of `airflow` takes precedence by overwriting `/usr/local/lib/service_venv/bin/airflow` with a script that just calls our patched version at `/srv/service/current/bin/airflow` (from the ETL repository). See this salt-state [1].

That doesn't work anymore, because with the rollout of frozen_venvs we can't count on `airflow` being at a hardcoded path. https://github.com/lyft/etl/pull/6073 was one attempt to solve this by finding the service_venv root dynamically. That approach doesn't work, because it depends on `service_venv` being available by the time the Jinja template is rendered, but `service_venv` won't be available until it's created in the lyft-python state (which requires that the template is rendered).

# Solution

We can avoid this chicken and egg problem if we simply patch the Airflow code directly, rather than trying to overwrite it on deployment. We apply our patch iff the `prefer_ip_over_hostname` key under the `lyft`
configuration section is set.

# Rollout

On the sharedairflowworker (which is only running test DAGs so far), we will stop overwriting the airflow command with our patched version and set the `prefer_ip_over_hostname` key.

If this works, then we can take the same approach for the other ASGs. Until then, we will continue overwriting the `airflow` command under service_venv/ with our patched version from ETL.


cc @lyft/data-platform 

[1] https://github.com/lyft/etl/blob/master/ops/config/states/etl/init.sls#L50-L59