### PR TITLE
Remove symlink to docs directory

### DIFF
--- a/airflow/www/static/docs
+++ b/airflow/www/static/docs
@@ -1,1 +1,0 @@
-../../../docs/_build/html/


### PR DESCRIPTION
This symlink is left dangling when ETL builds airflow as a dependency, which is causing deployment to fail. Excerpt from the logs:

    /srv/salt/venv/bin/python /srv/pulldeploy/pulldeploy/deploy.py -p etl
    2017-07-19 20:17:42,202 INFO frozen_venv ./venvs/service directory
    created
    2017-07-19 20:17:57,857 ERROR Command failed: cp -RL
    /srv/venvs/service/* ./venvs/service
    2017-07-19 20:17:57,857 ERROR cp: cannot stat
    '/srv/venvs/service/trusty/service_venv/src/airflow/airflow/www/static/docs':
    No such file or directory

cc @lyft/data-platform 