### PR TITLE
Upgrade flask to 0.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         'croniter>=0.3.8, <0.4',
         'dill>=0.2.2, <0.3',
         'python-daemon>=2.1.1, <2.2',
-        'flask>=0.10.1, <0.11',
+        'flask>=0.10.1, <=0.12.1',
         'flask-admin>=1.4.0, <2.0.0',
         'flask-cache>=0.13.1, <0.14',
         'flask-login==0.2.11',


### PR DESCRIPTION
We have an open refactorator PR (https://github.com/lyft/etl/pull/6005) to upgrade flask in etl. Airflow depends on 0.11, so we need to bump the version here to unblock etl.

I tested locally in devbox and the web UI starts up fine.

cc @lyft/data-platform 