### PR TITLE
[DATA-4839] Upgrade flask-wtf to 0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
         'setproctitle>=1.1.8, <2',
         'sqlalchemy>=0.9.8',
         'thrift>=0.9.2, <0.10',
-        'Flask-WTF==0.12'
+        'Flask-WTF==0.14'
     ],
     extras_require={
         'all': devel_all,


### PR DESCRIPTION
Airflow 1.8 depends on `flask-wtf==0.14`, so in order to run airflow 1.8 and 1.7 side by side we need to force etl to upgrade from `flask-wtf==0.12` to `flask-wtf==0.14`.

cc @lyft/data-platform 