### PR TITLE
[DATA-4839] Do not delete queued TIs from invisible DAGs

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -575,7 +575,10 @@ class SchedulerJob(BaseJob):
         session.expunge_all()
         d = defaultdict(list)
         for ti in queued_tis:
-            if ti.dag_id not in dagbag.dags:
+            if ti.dag_id in ['long_running_test']:
+                self.logger.info(
+                    'Ignoring {} because this DAG is handled by the airflow 1.8 scheduler'.format(ti))
+            elif ti.dag_id not in dagbag.dags:
                 self.logger.info(
                     "DAG no longer in dagbag, deleting {}".format(ti))
                 session.delete(ti)


### PR DESCRIPTION
The airflow 1.7 scheduler deletes any queued TI's belonging to DAGs that are not in the DagBag [1].  Since we're filtering out DAGs whitelisted for 1.8 (just the long_running_test DAG for now), the scheduler thinks those TI's belong to a DAG that has been removed and deletes them before they get picked up by an airflow 1.8 worker.

With this change, we'll simply ignore any TI's from a DAG that we know is handled by the 1.8 scheduler.

[1] ```[2017-09-13 17:34:26,285] {jobs.py:580} INFO - DAG no longer in dagbag, deleting <TaskInstance: long_running_test.entrypoint 2017-08-30 00:00:00 [queued]>```

cc @lyft/data-platform 

