### PR TITLE
[DPTOOLS-50] Ignore presto_query_logs DAG during 1.8 migration

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -575,7 +575,7 @@ class SchedulerJob(BaseJob):
         session.expunge_all()
         d = defaultdict(list)
         for ti in queued_tis:
-            if ti.dag_id in ['long_running_test']:
+            if ti.dag_id in ['long_running_test', 'presto_query_logs']:
                 self.logger.info(
                     'Ignoring {} because this DAG is handled by the airflow 1.8 scheduler'.format(ti))
             elif ti.dag_id not in dagbag.dags:


### PR DESCRIPTION
This DAG will get scheduled by 1.8, so don't delete any of its "phantom" Task Instances which were created by the 1.8 scheduler.

cc @lyft/data-platform 