### PR TITLE
Add redshift_replication_other to 1.8 whitelist

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -575,7 +575,7 @@ class SchedulerJob(BaseJob):
         session.expunge_all()
         d = defaultdict(list)
         for ti in queued_tis:
-            if ti.dag_id in ['long_running_test', 'presto_query_logs']:
+            if ti.dag_id in ['long_running_test', 'presto_query_logs', 'redshift_replication_other']:
                 self.logger.info(
                     'Ignoring {} because this DAG is handled by the airflow 1.8 scheduler'.format(ti))
             elif ti.dag_id not in dagbag.dags:


### PR DESCRIPTION
Don't prioritize jobs in the `redshift_replication_other` DAG, which is handled by Airflow 1.8