### PR TITLE
[DPTOOLS-75] Add stats and log backtraces on heartbeat failure

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1442,7 +1442,12 @@ class SchedulerJob(BaseJob):
 
             # Call hearbeats
             self.logger.info("Heartbeating the executor")
-            self.executor.heartbeat()
+
+            try:
+                self.executor.heartbeat()
+            except Exception:
+                self.logger.exception("Error heartbeating the executor")
+                Stats.incr('executor_heartbeat_exception', 1, 1)
 
             # Process events from the executor
             self._process_executor_events()


### PR DESCRIPTION
These stats should give us more information about how often this happens
and the exact Exception that the scheduler receives (we could
potentially just have the scheduler ignore this exception and add alarms
on the number of times it occurs.)

See https://jira.lyft.net/browse/DPTOOLS-75 for context.

cc @lyft/data-platform 