### PR TITLE
[DPTOOLS-66] Read 1.8 whitelist from txt file in etl

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -574,8 +574,18 @@ class SchedulerJob(BaseJob):
             "Prioritizing {} queued jobs".format(len(queued_tis)))
         session.expunge_all()
         d = defaultdict(list)
+        ignored_dags = [
+            'long_running_test',
+            'presto_query_logs',
+            'redshift_replication_other',
+            'other',
+            'driver_propensity_v1',
+            'experimentation_metric_fraud',
+            'experimentation_metric_referral_pax',
+            'experimentation_metric_referral_dvr'
+        ]
         for ti in queued_tis:
-            if ti.dag_id in ['long_running_test', 'presto_query_logs', 'redshift_replication_other', 'other']:
+            if ti.dag_id in ignored_dags:
                 self.logger.info(
                     'Ignoring {} because this DAG is handled by the airflow 1.8 scheduler'.format(ti))
             elif ti.dag_id not in dagbag.dags:


### PR DESCRIPTION
Modifying the 1.8 whitelist currently requires changes in 3 places:

1. Salt files for building `.airflowignore` in the `etl` repo
2. jobs.py in `incubator-airflow/data-platform`
3. jobs.py in `incubator-airflow/data-platform-upgrade`

This reads this configuration from a config file in the `etl` repo so that
we only need to modify the `etl` repo to update the whitelist. Once this
is approved, I'll submit a PR in `etl` to pin to the new Airflow SHA and
add the whitelist .txt file.

Then I'll port this exact same logic to our airflow 1.8 branch.

cc @lyft/data-platform 