### PR TITLE
[DPTOOLS-82] Ignore missing TI if already removed

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4284,9 +4284,11 @@ class DagRun(Base):
             try:
                 task_from_dag = dag.get_task(ti.task_id)
             except AirflowException:
-                logging.exception("Failed to get task '{}' for dag '{}'. Marking it as removed.".format(ti, dag))
-                Stats.incr("task_removed_from_dag.{}".format(dag.dag_id), 1, 1)
-                if self.state is not State.RUNNING and not dag.partial:
+                if ti.state == State.REMOVED:
+                    pass  # ti has already been removed, just ignore it
+                elif self.state is not State.RUNNING and not dag.partial:
+                    logging.exception("Failed to get task '{}' for dag '{}'. Marking it as removed.".format(ti, dag))
+                    Stats.incr("task_removed_from_dag.{}".format(dag.dag_id), 1, 1)
                     ti.state = State.REMOVED
 
             task_now_present_in_dag = task_from_dag is not None


### PR DESCRIPTION
Our task removal metrics [1] are skewed because we are constantly
marking the same tasks as removed over and over again. If we see that a
TI that is not in the DAG is already in state `REMOVED` in the database,
we can simply ignore it without increasing our counter or logging an
exception.

[1] https://lyft.wavefront.com/u/chvzlGtKQh

cc @lyft/data-platform 