### PR TITLE
[DPTOOLS-93] Remove Canary whitelist

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -553,13 +553,6 @@ class SchedulerJob(BaseJob):
             self.run_duration = conf.getint('scheduler',
                                             'run_duration')
 
-        # Temporary: remove once etl upgrade from 1.7 to 1.8 is complete
-        with open('/srv/service/current/canary_whitelist.txt', 'r') as f:
-            self.canary_whitelist = [entry.strip() for entry in f.readlines() if entry]
-
-        logging.info('Treating these {} DAGs as whitelisted for canary: {}'.format(
-                len(self.canary_whitelist), self.canary_whitelist))
-
     @provide_session
     def manage_slas(self, dag, session=None):
         """
@@ -1369,10 +1362,9 @@ class SchedulerJob(BaseJob):
             no_backfills=True,
         )
         for dr in active_runs:
-            if dr.dag_id in self.canary_whitelist:
-                self.logger.info("Resetting {} {}".format(dr.dag_id,
-                                                        dr.execution_date))
-                self.reset_state_for_orphaned_tasks(dr, session=session)
+            self.logger.info("Resetting {} {}".format(dr.dag_id,
+                                                      dr.execution_date))
+            self.reset_state_for_orphaned_tasks(dr, session=session)
 
         session.close()
 


### PR DESCRIPTION
We originally had this check so that the Canary scheduler running 1.8
wouldn't delete TI's that the 1.7 scheduler in Prod marked as QUEUED.
Now that 1.8 is the only scheduler, this logic is no longer needed.

Still trying to wrap my head around the implications, but I think this
could be why some of the metric_dryrun tasks last night got stuck in
state QUEUED after the etl deployment. Let's get rid of it and see if
that behavior goes away with the next deployment.

cc @lyft/data-platform 