### PR TITLE
[DPTOOLS-93] Log when we reset an orphaned task

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -230,7 +230,7 @@ class BaseJob(Base, LoggingMixin):
 
         for ti in tis:
             if ti.key not in queued_tis and ti.key not in running:
-                self.logger.debug("Rescheduling orphaned task {}".format(ti))
+                self.logger.info("Rescheduling orphaned task {}".format(ti))
                 ti.state = State.NONE
         session.commit()
 


### PR DESCRIPTION
This will give us more visibility into tasks getting stuck in state `QUEUED`.

cc @lyft/data-platform 