### PR TITLE
Refactorator: Apply manifesttypeandtier in lyftairflow

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,27 +1,26 @@
 name: lyftairflow
 description: Lyft internal fork of Airflow
 repository: git@github.com:lyft/incubator-airflow.git
-report_ci: True
-credentials: True
-
+report_ci: true
+credentials: true
 groups:
   - name: dev
     members:
       - control.dev
       - lyftairflow.legacy
-
 deploy:
   - name: staging
     role: lyftpypi-staging-iad-deploy
-    legacy: True
-    automatic: True
+    legacy: true
+    automatic: true
     orca:
       - orca_location: ops
         region: iad
   - name: production
     role: lyftpypi-production-iad-deploy
-    legacy: True
-    automatic: True
+    legacy: true
+    automatic: true
     orca:
       - orca_location: ops
         region: iad
+image_type: library


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR.  Refactorator will merge it automatically.  You still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control run refactorator.run fix --images lyftairflow -f manifesttypeandtier
```
# manifesttypeandtier
    This refactorator adds `image_type: XXX` to all manifests if not present. Additionally, it adds `service_tier: N` to 
    services with known service tier, if not already present. This PR will auto-merge and should not affect how your 
    service behaves.

For more information or questions reach out to [#perf-frameworks](https://lyft.slack.com/messages/perf-frameworks)
