### PR TITLE
Improve oauth redirection

### DIFF
--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -110,7 +110,7 @@ class GoogleAuthBackend(object):
         state = json.dumps(request.args.to_dict(flat=False))
         _log.debug('Redirecting user to Google login')
         return self.google_oauth.authorize(
-            callback=url_for('google_oauth_callback', _external=True, next='/admin/'),
+            callback=url_for('google_oauth_callback', _external=True),
             state=state)
 
     def get_google_user_profile_info(self, google_token):

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -146,7 +146,10 @@ class GoogleAuthBackend(object):
         _log.debug('Google OAuth callback called')
 
         state = json.loads(request.args.get('state'))
-        next_url = state['next'][0] or url_for('admin.index')
+        try:
+            next_url = state.get('next')[0]
+        except (IndexError, KeyError):
+            next_url = url_for('admin.index')
 
         resp = self.google_oauth.authorized_response()
 

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ password = [
     'bcrypt>=2.0.0',
     'flask-bcrypt>=0.7.1',
 ]
-github_enterprise = ['Flask-OAuthlib>=0.9.1']
+github_enterprise = ['Flask-OAuthlib>=0.9.1', 'PyJWT>=1.5.3']
 qds = ['qds-sdk>=1.9.0']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 redis = ['redis>=2.10.5']

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,8 @@ password = [
     'bcrypt>=2.0.0',
     'flask-bcrypt>=0.7.1',
 ]
-github_enterprise = ['Flask-OAuthlib>=0.9.1', 'PyJWT>=1.5.3']
+github_enterprise = ['Flask-OAuthlib>=0.9.1']
+google_authentication = ['Flask-OAuthlib>=0.9.1', 'PyJWT>=1.5.3']
 qds = ['qds-sdk>=1.9.0']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 redis = ['redis>=2.10.5']
@@ -249,6 +250,7 @@ def do_setup():
             'emr': emr,
             'gcp_api': gcp_api,
             'github_enterprise': github_enterprise,
+            'google_authentication': google_authentication,
             'hdfs': hdfs,
             'hive': hive,
             'jdbc': jdbc,


### PR DESCRIPTION
This PR improves the Google OAuth redirection. Currently, when an employee tries to visit a pipeline without being authenticated, eg:

http://etl.lyft.net/admin/airflow/tree?dag_id=foo

After getting the employee credentials the authentication process will redirect the user back to:

http://etl.lyft.net/oauth2callback?next=%2Fadmin%2Fairflow%2Ftree%3Fdag_id%3Dfoo

But this fails because that url is not registered as a valid callback (currently, only http://etl.lyft.net/oauth2callback?next=%2Fadmin%2F is valid).

The correct way of handling dynamic redirects is to store the state in a `state` URL parameter (see the [documentation](http://flask-oauthlib.readthedocs.io/en/latest/api.html#flask_oauthlib.client.OAuthRemoteApp.authorize)). I tested Airflow with these changes, and the user is correctly redirected to the DAG after authenticating.

:eyes: @mistercrunch, this PR changes the OAuth redirect URL, removing the `next` parameter from it. Before deploying this we need to add http://etl.lyft.net/oauth2callback as a valid redirect URL in the Google console.