### PR TITLE
[DPTOOLS-250] Fix dag with status 'This DAG isn't available'

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1365,6 +1365,8 @@ class SchedulerJob(BaseJob):
         self.executor.start()
 
         session = settings.Session()
+        models.DAG.deactivate_all_dags()
+
         self.logger.info("Resetting state for orphaned tasks")
         # grab orphaned tasks and make sure to reset their state
         active_runs = DagRun.find(
@@ -1503,6 +1505,7 @@ class SchedulerJob(BaseJob):
             if processor_manager.get_last_finish_time(file_path) is None:
                 all_files_processed = False
                 break
+
         if all_files_processed:
             self.logger.info("Deactivating DAGs that haven't been touched since {}"
                              .format(execute_start_time.isoformat()))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3507,6 +3507,21 @@ class DAG(BaseDag, LoggingMixin):
 
     @staticmethod
     @provide_session
+    def deactivate_all_dags(session=None):
+        """
+        Deactivate all the existing dags to be in active.
+
+        :param session:
+        :return:
+        """
+        for dag in session.query(
+                DagModel).all():
+            dag.is_active = False
+            session.merge(dag)
+            session.commit()
+
+    @staticmethod
+    @provide_session
     def deactivate_unknown_dags(active_dag_ids, session=None):
         """
         Given a list of known DAGs, deactivate any other DAGs that are
@@ -3516,13 +3531,13 @@ class DAG(BaseDag, LoggingMixin):
         :type active_dag_ids: list[unicode]
         :return: None
         """
-
         if len(active_dag_ids) == 0:
             return
         for dag in session.query(
                 DagModel).filter(~DagModel.dag_id.in_(active_dag_ids)).all():
             dag.is_active = False
             session.merge(dag)
+            session.commit()
 
     @staticmethod
     @provide_session


### PR DESCRIPTION
This PR addresses the issue(https://jira.lyft.net/browse/DPTOOLS-250) that bunches of DAGs that are outdated are still shown up in Airflow UI because of its is_active flag is False. The root cause is because Airflow scheduler runs in an infinite loop(duration is -1), and when we restart airflow scheduler, the clean up routine is never called(https://github.com/lyft/incubator-airflow/blob/master/airflow/jobs.py#L1489). 

This PR will have scheduler clear all the existing Dags is_active flag to False. All the latest dags is_active flag will be set back to True when scheduler starts up.

I have tested the change locally.

(Let me know if there are cases I miss:) )