### PR TITLE
[DPTOOLS-263] Reduce airflow tree view pageload time

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -34,7 +34,7 @@ class DateTimeWithNumRunsForm(Form):
     # and landing times
     base_date = DateTimeField(
         "Anchor date", widget=DateTimePickerWidget(), default=datetime.now())
-    num_runs = SelectField("Number of runs", default=25, choices=(
+    num_runs = SelectField("Number of runs", default=5, choices=(
         (5, "5"),
         (25, "25"),
         (50, "50"),


### PR DESCRIPTION
Changing default "num_runs" from 25 to 5 helps to reduce page load time significantly.

Pageload time for Default(25) is around ~46 seconds for metric_dryrun DAG
Pageload time for new default(5) is around ~13 seconds for metric_dryrun DAG.