### PR TITLE
[DPTOOLS-263] Reduce airflow tree view pageload time

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1155,7 +1155,7 @@ class Airflow(BaseView):
 
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else 5
 
         if base_date:
             base_date = dateutil.parser.parse(base_date)
@@ -1384,7 +1384,7 @@ class Airflow(BaseView):
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else 5
 
         if base_date:
             base_date = dateutil.parser.parse(base_date)
@@ -1480,7 +1480,7 @@ class Airflow(BaseView):
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else 5
 
         if base_date:
             base_date = dateutil.parser.parse(base_date)
@@ -1544,7 +1544,7 @@ class Airflow(BaseView):
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else 5
 
         if base_date:
             base_date = dateutil.parser.parse(base_date)


### PR DESCRIPTION
Changing default "num_runs" from 25 to 5 helps to reduce page load time significantly. Add couples of additional change .

Pageload time for Default(25) is around ~46 seconds for metric_dryrun DAG
Pageload time for new default(5) is around ~13 seconds for metric_dryrun DAG.