### PR TITLE
[DPTOOLS-346] Instrument Airflow CLI

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -54,6 +54,7 @@ from airflow.utils import db as db_utils
 from airflow.utils import logging as logging_utils
 from airflow.utils.file import mkdirs
 from airflow.www.app import cached_app
+from airflow.utils import clis
 
 from sqlalchemy import func
 from sqlalchemy.orm import exc
@@ -127,6 +128,7 @@ def get_dag(args):
     return dagbag.dags[args.dag_id]
 
 
+@clis.action_logging
 def backfill(args, dag=None):
     logging.basicConfig(
         level=settings.LOGGING_LEVEL,
@@ -167,6 +169,7 @@ def backfill(args, dag=None):
             pool=args.pool)
 
 
+@clis.action_logging
 def trigger_dag(args):
     """
     Creates a dag run for the specified dag
@@ -185,6 +188,7 @@ def trigger_dag(args):
     logging.info(message)
 
 
+@clis.action_logging
 def pool(args):
     session = settings.Session()
     if args.get or (args.set and args.set[0]) or args.delete:
@@ -218,6 +222,7 @@ def pool(args):
         print("Pool {} deleted".format(name))
 
 
+@clis.action_logging
 def variables(args):
 
     if args.get:
@@ -295,10 +300,12 @@ def export_helper(filepath):
     print("{} variables successfully exported to {}".format(len(var_dict), filepath))
 
 
+@clis.action_logging
 def pause(args, dag=None):
     set_is_paused(True, args, dag)
 
 
+@clis.action_logging
 def unpause(args, dag=None):
     set_is_paused(False, args, dag)
 
@@ -316,6 +323,7 @@ def set_is_paused(is_paused, args, dag=None):
     print(msg)
 
 
+@clis.action_logging
 def run(args, dag=None):
     # Disable connection pooling to reduce the # of connections on the DB
     # while it's waiting for the task to finish.
@@ -496,6 +504,7 @@ def run(args, dag=None):
                 'Unsupported remote log location: {}'.format(remote_base))
 
 
+@clis.action_logging
 def task_failed_deps(args):
     """
     Returns the unmet dependencies for a task instance from the perspective of the
@@ -521,6 +530,7 @@ def task_failed_deps(args):
         print("Task instance dependencies are all met.")
 
 
+@clis.action_logging
 def task_state(args):
     """
     Returns the state of a TaskInstance at the command line.
@@ -534,6 +544,7 @@ def task_state(args):
     print(ti.current_state())
 
 
+@clis.action_logging
 def dag_state(args):
     """
     Returns the state of a DagRun at the command line.
@@ -546,6 +557,7 @@ def dag_state(args):
     print(dr[0].state if len(dr) > 0 else None)
 
 
+@clis.action_logging
 def list_dags(args):
     dagbag = DagBag(process_subdir(args.subdir))
     s = textwrap.dedent("""\n
@@ -560,6 +572,7 @@ def list_dags(args):
         print(dagbag.dagbag_report())
 
 
+@clis.action_logging
 def list_tasks(args, dag=None):
     dag = dag or get_dag(args)
     if args.tree:
@@ -569,6 +582,7 @@ def list_tasks(args, dag=None):
         print("\n".join(sorted(tasks)))
 
 
+@clis.action_logging
 def test(args, dag=None):
     dag = dag or get_dag(args)
 
@@ -585,6 +599,7 @@ def test(args, dag=None):
         ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
 
 
+@clis.action_logging
 def render(args):
     dag = get_dag(args)
     task = dag.get_task(task_id=args.task_id)
@@ -599,6 +614,7 @@ def render(args):
         """.format(attr, getattr(task, attr))))
 
 
+@clis.action_logging
 def clear(args):
     logging.basicConfig(
         level=settings.LOGGING_LEVEL,
@@ -728,6 +744,7 @@ def restart_workers(gunicorn_master_proc, num_workers_expected):
                 start_refresh(gunicorn_master_proc)
 
 
+@clis.action_logging
 def webserver(args):
     print(settings.HEADER)
 
@@ -849,6 +866,7 @@ def webserver(args):
             monitor_gunicorn(gunicorn_master_proc)
 
 
+@clis.action_logging
 def scheduler(args):
     print(settings.HEADER)
     job = jobs.SchedulerJob(
@@ -882,6 +900,7 @@ def scheduler(args):
         job.run()
 
 
+@clis.action_logging
 def serve_logs(args):
     print("Starting flask")
     import flask
@@ -901,6 +920,7 @@ def serve_logs(args):
         host='0.0.0.0', port=WORKER_LOG_SERVER_PORT)
 
 
+@clis.action_logging
 def worker(args):
     env = os.environ.copy()
     env['AIRFLOW_HOME'] = settings.AIRFLOW_HOME
@@ -946,12 +966,14 @@ def worker(args):
         sp.kill()
 
 
+@clis.action_logging
 def initdb(args):  # noqa
     print("DB: " + repr(settings.engine.url))
     db_utils.initdb()
     print("Done.")
 
 
+@clis.action_logging
 def resetdb(args):
     print("DB: " + repr(settings.engine.url))
     if args.yes or input(
@@ -964,6 +986,7 @@ def resetdb(args):
         print("Bail.")
 
 
+@clis.action_logging
 def upgradedb(args):  # noqa
     print("DB: " + repr(settings.engine.url))
     db_utils.upgradedb()
@@ -981,10 +1004,12 @@ def upgradedb(args):  # noqa
         session.commit()
 
 
+@clis.action_logging
 def version(args):  # noqa
     print(settings.HEADER + "  v" + airflow.__version__)
 
 
+@clis.action_logging
 def connections(args):
     if args.list:
         # Check that no other flags were passed to the command
@@ -1088,6 +1113,7 @@ def connections(args):
         return
 
 
+@clis.action_logging
 def flower(args):
     broka = conf.get('celery', 'BROKER_URL')
     address = '--address={}'.format(args.hostname)
@@ -1123,6 +1149,7 @@ def flower(args):
         os.execvp("flower", ['flower', '-b', broka, address, port, api, flower_conf])
 
 
+@clis.action_logging
 def kerberos(args):  # noqa
     print(settings.HEADER)
     import airflow.security.kerberos

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -148,6 +148,11 @@ def configure_orm(disable_connection_pool=False):
     Session = scoped_session(
         sessionmaker(autocommit=False, autoflush=False, bind=engine))
 
+
+def configure_action_logging():
+    pass
+
+
 try:
     from airflow_local_settings import *
     logging.info("Loaded airflow_local_settings.")
@@ -157,6 +162,7 @@ except:
 configure_logging()
 configure_vars()
 configure_orm()
+configure_action_logging()
 
 # Const stuff
 

--- a/airflow/utils/action_loggers.py
+++ b/airflow/utils/action_loggers.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+A Action Logger module. Singleton pattern has been applied into this module so that injected action loggers can be used
+all through the same python process.
+"""
+from __future__ import absolute_import
+import logging
+import airflow.settings
+
+
+class DefaultActionLogger:
+    """
+    A default action logger that behave same as www.utils.action_logging which uses global session
+    and pushes log DAO object.
+    """
+    def __init__(self):
+        pass
+
+    @classmethod
+    def submit(cls, **kwargs):
+        log = kwargs.get('log')
+        if log is None:
+            logging.warn("log object is not found skipping")
+            return
+
+        session = airflow.settings.Session()
+        session.add(log)
+        session.commit()
+
+
+def add(action_logger):
+    """
+    Adds more action logger. This is intended for any use case to inject customized action logger.
+    :param action_logger: An action logger implementation
+    :return: None
+    """
+    logging.debug("Adding {}".format(action_logger))
+    __action_loggers.append(action_logger)
+
+
+def submit(**kwargs):
+    """
+    Submits log using registered action loggers.
+    :param kwargs:
+    :return: None
+    """
+    logging.debug("Submitting report: {}".format(__action_loggers))
+    for r in __action_loggers:
+        r.submit(**kwargs)
+
+
+__action_loggers = []
+# By default, add Default action logger
+add(DefaultActionLogger())

--- a/airflow/utils/clis.py
+++ b/airflow/utils/clis.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Utilities module for cli
+"""
+from __future__ import absolute_import
+import functools
+from datetime import datetime
+import sys
+import os
+
+import airflow.models
+from airflow.utils import action_loggers
+
+
+def action_logging(f):
+    """
+    Decorates function to execute function at the same time submitting action_logging but in CLI context
+    :param f: function instance
+    :return: wrapped function
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        metrics = _build_metrics(f.__name__, *args)
+
+        try:
+            result = f(*args, **kwargs)
+        except:
+            metrics['error'] = sys.exc_info()[1]
+        finally:
+            metrics['end_datetime'] = datetime.utcnow()
+            try:
+                action_loggers.submit(**metrics)
+            finally:
+                return result
+    return wrapper
+
+
+def _build_metrics(func_name, *args):
+    """
+    Builds metrics dict from function args
+    :param func_name: name of function
+    :param args: args
+    :return: dict with metrics
+    """
+    metrics = {'event': func_name}
+    metrics['start_datetime'] = datetime.utcnow()
+    metrics['full_command'] = str(list(sys.argv))
+    metrics['user'] = os.environ.get('USER')
+
+    print "args[0]: {}".format(args[0])
+    if args:
+        tmp_dic = vars(args[0])
+        metrics['dag_id'] = tmp_dic.get('dag_id')
+        metrics['task_id'] = tmp_dic.get('task_id')
+        metrics['execution_date'] = tmp_dic.get('execution_date')
+
+    log = airflow.models.Log(
+        event=func_name,
+        task_instance=None,
+        owner=metrics['user'],
+        extra=str(metrics['full_command']),
+        task_id=metrics.get('task_id'),
+        dag_id=metrics.get('dag_id'),
+        execution_date=metrics.get('execution_date'))
+    metrics['log'] = log
+    return metrics


### PR DESCRIPTION
https://jira.lyft.net/browse/DPTOOLS-346
Added instrumentation so that by default it will perform action logging same as what Airflow does from Web UI. On instrumentation, it was made to be injectable so that additional instrumentation is pluggable in runtime. This will be contribute back to open source so that it won't be isolated in forked version.

Updated:
 - settings.py: added module function "configure_action_logging" to inject custom implementation. (separate PR will come for ETL library)
 - cli.py: added annotation on all airflow cli's subcommand

Added:
 - clis.py: function decorator that submits action_logging (for our use case, it pushes to postgres just as what it's doing for web api, and pushes via AnalyticsClientEvent)
 - action_logger.py: A module that can be used as a singleton action_logger where you can add your own action_logger (our ETL framework will add AnalyticsClientEvent via this).


Integration tested in devbox:
service_venv airflow test long_running_test entrypoint 2017-01-01
In Postgres:
`id |            dttm            |      dag_id       |  task_id   | event |   execution_date    | owner |                                                      extra                                                      
----+----------------------------+-------------------+------------+-------+---------------------+-------+-----------------------------------------------------------------------------------------------------------------
 15 | 2018-03-19 20:55:49.858203 | long_running_test | entrypoint | test  | 2017-01-01 00:00:00 | root  | ['/srv/venvs/service/trusty/service_venv/bin/airflow', 'test', 'long_running_test', 'entrypoint', '2017-01-01']`
 

Analytics event:
` id  |               event_id               |       event_name        |    property_name    |                                         property_value                                          |         created_at         
-----+--------------------------------------+-------------------------+---------------------+-------------------------------------------------------------------------------------------------+----------------------------
 209 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | reporter_hostname   | etl-legacy                                                                                      | 2018-03-19 20:56:33.979145
 210 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | reporter_ip_address | 172.17.0.5                                                                                      | 2018-03-19 20:56:33.979145
 211 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | cli_version_number  | dd38933e8a8e658a6f3ba2a894deb91cacf22c84                                                        | 2018-03-19 20:56:33.979145
 212 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | occurred_at         | 2018-03-19 20:56:32.608810                                                                      | 2018-03-19 20:56:33.979145
 213 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | request_ended_at    | 2018-03-19 20:56:32.561561                                                                      | 2018-03-19 20:56:33.979145
 214 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | hostname            | etl-legacy                                                                                      | 2018-03-19 20:56:33.979145
 215 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | cli_full_command    | /srv/venvs/service/trusty/service_venv/bin/airflow test long_running_test entrypoint 2017-01-01 | 2018-03-19 20:56:33.979145
 216 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | exit_code           | 0                                                                                               | 2018-03-19 20:56:33.979145
 217 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | method              | test                                                                                            | 2018-03-19 20:56:33.979145
 218 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | request_started_at  | 2018-03-19 20:55:49.840826                                                                      | 2018-03-19 20:56:33.979145
 219 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | __metadata__        | {"logged_at": "1521492992.61", "aic_time": "1521492992615"}                                     | 2018-03-19 20:56:33.979145
 220 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | source_pipeline     | streamingest                                                                                    | 2018-03-19 20:56:33.979145
 221 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | logged_at           | 2018-03-19 20:56:33.979145                                                                      | 2018-03-19 20:56:33.979145
 222 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | os                  | Linux                                                                                           | 2018-03-19 20:56:33.979145
 223 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | command_type        | airflow_cli                                                                                     | 2018-03-19 20:56:33.979145
 224 | 9a442def-949b-49c0-a657-625819a87a83 | etl_cli_command_invoked | user_name           | jinchang                                                                                        | 2018-03-19 20:56:33.979145`
