### PR TITLE
Revert "add skip_dagbag flag for resetdb cli"

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1036,7 +1036,7 @@ def resetdb(args):
             "Proceed? (y/n)").upper() == "Y":
         logging.basicConfig(level=settings.LOGGING_LEVEL,
                             format=settings.SIMPLE_LOG_FORMAT)
-        db_utils.resetdb(skip_dagbag=args.skip_dagbag)
+        db_utils.resetdb()
     else:
         print("Bail.")
 
@@ -1481,11 +1481,6 @@ class CLIFactory(object):
             "Do not prompt to confirm reset. Use with care!",
             "store_true",
             default=False),
-        'skip_dagbag': Arg(
-            ("-sd", "--skip_dagbag"),
-            "Do not load DagBag() during resetdb",
-            "store_true",
-            default=False),
         # scheduler
         'dag_id_opt': Arg(("-d", "--dag_id"), help="The id of the dag to run"),
         'run_duration': Arg(
@@ -1663,7 +1658,7 @@ class CLIFactory(object):
         }, {
             'func': resetdb,
             'help': "Burn down and rebuild the metadata database",
-            'args': ('yes', 'skip_dagbag'),
+            'args': ('yes',),
         }, {
             'func': upgradedb,
             'help': "Upgrade the metadata database to latest version",

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -99,7 +99,7 @@ def checkout(dbapi_connection, connection_record, connection_proxy):
         )
 
 
-def initdb(skip_dagbag=False):
+def initdb():
     session = settings.Session()
 
     from airflow import models
@@ -256,14 +256,13 @@ def initdb(skip_dagbag=False):
         session.add(KET(know_event_type='Marketing Campaign'))
     session.commit()
 
-    if not skip_dagbag:
-        dagbag = models.DagBag()
-        # Save individual DAGs in the ORM
-        now = datetime.utcnow()
-        for dag in dagbag.dags.values():
-            models.DAG.sync_to_db(dag, dag.owner, now)
-        # Deactivate the unknown ones
-        models.DAG.deactivate_unknown_dags(dagbag.dags.keys())
+    dagbag = models.DagBag()
+    # Save individual DAGs in the ORM
+    now = datetime.utcnow()
+    for dag in dagbag.dags.values():
+        models.DAG.sync_to_db(dag, dag.owner, now)
+    # Deactivate the unknown ones
+    models.DAG.deactivate_unknown_dags(dagbag.dags.keys())
 
     Chart = models.Chart
     chart_label = "Airflow task instance by type"
@@ -295,7 +294,7 @@ def upgradedb():
     command.upgrade(config, 'heads')
 
 
-def resetdb(skip_dagbag=False):
+def resetdb():
     '''
     Clear out the database
     '''
@@ -306,4 +305,4 @@ def resetdb(skip_dagbag=False):
     mc = MigrationContext.configure(settings.engine)
     if mc._version.exists(settings.engine):
         mc._version.drop(settings.engine)
-    initdb(skip_dagbag)
+    initdb()


### PR DESCRIPTION
Reverts lyft/incubator-airflow#52

1. We can try .airflowignore to achieve the same thing
2. -sd flag already exists in CLI