### PR TITLE
[AIRFLOW-1573] Allow upgrade of thrift version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,7 +236,7 @@ def do_setup():
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=0.9.8',
             'tabulate>=0.7.5, <0.8.0',
-            'thrift>=0.9.2, <0.10',
+            'thrift>=0.9.2',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={


### PR DESCRIPTION
This change was already made upstream in https://issues.apache.org/jira/browse/AIRFLOW-1573.

PyHive requires thrift>=0.10, but our version of Airflow requires <0.10

cc @lyft/dp-tools-viz 