### PR TITLE
Make airflow DAG templating accept number

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -35,6 +35,7 @@ import zipfile
 import jinja2
 import json
 import logging
+from numbers import Number
 import os
 import pickle
 import re
@@ -2280,6 +2281,8 @@ class BaseOperator(object):
             result = {
                 k: rt("{}[{}]".format(attr, k), v, context)
                 for k, v in list(content.items())}
+        elif isinstance(content, Number):
+            result = content
         else:
             param_type = type(content)
             msg = (


### PR DESCRIPTION
Currently, if you have an operator with a template fields argument, that is a dictionary, e.g.:
`template_fields = ([dict_args])`

And you populate that dictionary with a field that an integer in a DAG, e.g.:
```
...
dict_args = {'ds': '{{ ds }}', num_times: 5}
...
```

Then ariflow will give you the following error:
`{base_task_runner.py:95} INFO - Subtask: airflow.exceptions.AirflowException: Type '<type 'int'>' used for parameter 'dict_args[num_times]' is not supported for templating`

This fix aims to resolve that issue

