### PR TITLE
[DPTOOLS-604] Remove deprecate warning

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -36,9 +36,9 @@ from .exceptions import AirflowConfigException
 
 # show Airflow's deprecation warnings
 warnings.filterwarnings(
-    action='default', category=DeprecationWarning, module='airflow')
+    action='ignore', category=DeprecationWarning, module='airflow')
 warnings.filterwarnings(
-    action='default', category=PendingDeprecationWarning, module='airflow')
+    action='ignore', category=PendingDeprecationWarning, module='airflow')
 
 
 try:

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -19,8 +19,7 @@ import six
 from flask import Flask
 from flask_admin import Admin, base
 from flask_cache import Cache
-from flask_wtf.csrf import CsrfProtect
-csrf = CsrfProtect()
+from flask_wtf.csrf import CSRFProtect
 
 import airflow
 from airflow import models
@@ -30,6 +29,9 @@ from airflow.www.blueprints import routes
 from airflow import jobs
 from airflow import settings
 from airflow import configuration
+
+
+csrf = CSRFProtect()
 
 
 def create_app(config=None, testing=False):


### PR DESCRIPTION
Not sure why we have these warning in airflow(https://github.com/apache/incubator-airflow/pull/1285).

But we won't show it in our lyft repo:) 