### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,15 +100,6 @@ def write_version(filename=os.path.join(*['airflow',
         a.write(text)
 
 
-def check_previous():
-    installed_packages = ([package.project_name for package
-                           in pip.get_installed_distributions()])
-    if 'airflow' in installed_packages:
-        print("An earlier non-apache version of Airflow was installed, "
-              "please uninstall it first. Then reinstall.")
-        sys.exit(1)
-
-
 async = [
     'greenlet>=0.4.9',
     'eventlet>= 0.9.7',
@@ -196,7 +187,6 @@ devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docke
 
 
 def do_setup():
-    check_previous()
     write_version()
     setup(
         name='apache-airflow',


### PR DESCRIPTION
Removed `check_previous` from setup.py as `pip.get_installed_distributions()` throws error and `check_previous` is removed in the upstream.

https://github.com/apache/incubator-airflow/blob/master/setup.py#L233-L235

```
Traceback (most recent call last):
  File "setup.py", line 305, in <module>
    do_setup()
  File "setup.py", line 199, in do_setup
    check_previous()
  File "setup.py", line 105, in check_previous
    in pip.get_installed_distributions()])
AttributeError: 'module' object has no attribute 'get_installed_distributions'
```