### PR TITLE
Backfill support schedule_interval override through CLI

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -153,7 +153,6 @@ def backfill(args, dag=None):
 
     if schedule_interval:
         dag.schedule_interval = schedule_interval
-        dag._schedule_interval = schedule_interval
 
     if args.task_regex:
         dag = dag.sub_dag(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2202,7 +2202,7 @@ class BaseOperator(object):
         schedule_interval as it may not be attached to a DAG.
         """
         if self.has_dag():
-            return self.dag._schedule_interval
+            return self.dag.schedule_interval
         else:
             return self._schedule_interval
 
@@ -2736,11 +2736,11 @@ class DAG(BaseDag, LoggingMixin):
         self.end_date = end_date
         self.schedule_interval = schedule_interval
         if schedule_interval in cron_presets:
-            self._schedule_interval = cron_presets.get(schedule_interval)
+            self.schedule_interval = cron_presets.get(schedule_interval)
         elif schedule_interval == '@once':
-            self._schedule_interval = None
+            self.schedule_interval = None
         else:
-            self._schedule_interval = schedule_interval
+            self.schedule_interval = schedule_interval
         if isinstance(template_searchpath, six.string_types):
             template_searchpath = [template_searchpath]
         self.template_searchpath = template_searchpath
@@ -2818,21 +2818,21 @@ class DAG(BaseDag, LoggingMixin):
             end_date = None
         return utils_date_range(
             start_date=start_date, end_date=end_date,
-            num=num, delta=self._schedule_interval)
+            num=num, delta=self.schedule_interval)
 
     def following_schedule(self, dttm):
-        if isinstance(self._schedule_interval, six.string_types):
-            cron = croniter(self._schedule_interval, dttm)
+        if isinstance(self.schedule_interval, six.string_types):
+            cron = croniter(self.schedule_interval, dttm)
             return cron.get_next(datetime)
-        elif isinstance(self._schedule_interval, timedelta):
-            return dttm + self._schedule_interval
+        elif isinstance(self.schedule_interval, timedelta):
+            return dttm + self.schedule_interval
 
     def previous_schedule(self, dttm):
-        if isinstance(self._schedule_interval, six.string_types):
-            cron = croniter(self._schedule_interval, dttm)
+        if isinstance(self.schedule_interval, six.string_types):
+            cron = croniter(self.schedule_interval, dttm)
             return cron.get_prev(datetime)
-        elif isinstance(self._schedule_interval, timedelta):
-            return dttm - self._schedule_interval
+        elif isinstance(self.schedule_interval, timedelta):
+            return dttm - self.schedule_interval
 
     def normalize_schedule(self, dttm):
         """

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ def do_setup():
             'funcsigs>=1.0.0, <=1.0.2',
             'future>=0.15.0, <0.16',
             'gitpython>=2.0.2',
-            #'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
+            'gunicorn>=19.3.0, < 19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.7.3, <=2.9.5',
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',


### PR DESCRIPTION
airflow backfill supports overriding the DAG's schedule_interval CLI.

For example:
`backfill hello_world -s 2018-03-01 -e 2018-03-08 --schedule_interval "0 0 */2 * *"` or
`backfill hello_world -s 2018-03-01 -e 2018-03-08 --schedule_interval @weekly`