### PR TITLE
[DPTOOLS-599] backfill support passing key values through CLI

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -149,6 +149,10 @@ def backfill(args, dag=None):
             task_regex=args.task_regex,
             include_upstream=not args.ignore_dependencies)
 
+    run_conf = None
+    if args.conf:
+        run_conf = json.loads(args.conf)
+
     if args.dry_run:
         print("Dry run of DAG {0} on {1}".format(args.dag_id,
                                                  args.start_date))
@@ -167,7 +171,8 @@ def backfill(args, dag=None):
                           conf.getboolean('core', 'donot_pickle')),
             ignore_first_depends_on_past=args.ignore_first_depends_on_past,
             ignore_task_deps=args.ignore_dependencies,
-            pool=args.pool)
+            pool=args.pool,
+            conf=run_conf)
 
 
 @cli.action_logging
@@ -1302,6 +1307,9 @@ class CLIFactory(object):
                 "DO respect depends_on_past)."),
             "store_true"),
         'pool': Arg(("--pool",), "Resource pool to use"),
+        'conf': Arg(
+            ('-c', '--conf'),
+            "JSON string that gets pickled into the DagRun's conf attribute"),
         # list_tasks
         'tree': Arg(("-t", "--tree"), "Tree view", "store_true"),
         # list_dags
@@ -1560,7 +1568,7 @@ class CLIFactory(object):
                 'dag_id', 'task_regex', 'start_date', 'end_date',
                 'mark_success', 'local', 'donot_pickle', 'include_adhoc',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
-                'subdir', 'pool', 'dry_run')
+                'subdir', 'pool', 'dry_run', 'conf')
         }, {
             'func': list_tasks,
             'help': "List the tasks within a DAG",

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1834,7 +1834,7 @@ class BackfillJob(BaseJob):
                     state=State.RUNNING,
                     external_trigger=False,
                     session=session,
-                    conf=self.conf
+                    conf=self.conf,
                 )
             else:
                 run = run[0]

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1670,6 +1670,7 @@ class BackfillJob(BaseJob):
             ignore_first_depends_on_past=False,
             ignore_task_deps=False,
             pool=None,
+            conf=None,
             *args, **kwargs):
         self.dag = dag
         self.dag_id = dag.dag_id
@@ -1681,6 +1682,7 @@ class BackfillJob(BaseJob):
         self.ignore_first_depends_on_past = ignore_first_depends_on_past
         self.ignore_task_deps = ignore_task_deps
         self.pool = pool
+        self.conf = conf
         super(BackfillJob, self).__init__(*args, **kwargs)
 
     def _update_counters(self, started, succeeded, skipped, failed, tasks_to_run):
@@ -1832,6 +1834,7 @@ class BackfillJob(BaseJob):
                     state=State.RUNNING,
                     external_trigger=False,
                     session=session,
+                    conf=self.conf
                 )
             else:
                 run = run[0]

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3400,7 +3400,8 @@ class DAG(BaseDag, LoggingMixin):
             ignore_task_deps=False,
             ignore_first_depends_on_past=False,
             pool=None,
-            conf=None):
+            conf=None,
+    ):
         """
         Runs the DAG.
         """

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3399,7 +3399,8 @@ class DAG(BaseDag, LoggingMixin):
             donot_pickle=configuration.getboolean('core', 'donot_pickle'),
             ignore_task_deps=False,
             ignore_first_depends_on_past=False,
-            pool=None):
+            pool=None,
+            conf=None):
         """
         Runs the DAG.
         """
@@ -3418,7 +3419,8 @@ class DAG(BaseDag, LoggingMixin):
             donot_pickle=donot_pickle,
             ignore_task_deps=ignore_task_deps,
             ignore_first_depends_on_past=ignore_first_depends_on_past,
-            pool=pool)
+            pool=pool,
+            conf=conf)
         job.run()
 
     def cli(self):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3421,7 +3421,8 @@ class DAG(BaseDag, LoggingMixin):
             ignore_task_deps=ignore_task_deps,
             ignore_first_depends_on_past=ignore_first_depends_on_past,
             pool=pool,
-            conf=conf)
+            conf=conf,
+        )
         job.run()
 
     def cli(self):

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime
+import json
 import logging
 import os
 import shutil
@@ -168,6 +169,33 @@ class BackfillJobTest(unittest.TestCase):
                 end_date=DEFAULT_DATE,
                 ignore_first_depends_on_past=True)
             job.run()
+
+    def test_backfill_conf(self):
+        dag = DAG(
+            dag_id='test_backfill_conf',
+            start_date=DEFAULT_DATE,
+            schedule_interval='@daily')
+
+        with dag:
+            DummyOperator(
+                task_id='op',
+                dag=dag)
+
+        dag.clear()
+
+        executor = TestExecutor(do_update=True)
+
+        conf = json.loads("""{"key": "value"}""")
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          conf=conf)
+        job.run()
+
+        dr = DagRun.find(dag_id='test_backfill_conf')
+
+        self.assertEqual(conf, dr[0].conf)
 
     def test_backfill_ordered_concurrent_execute(self):
         dag = DAG(


### PR DESCRIPTION
In backfill, we can provide key-value pairs through CLI and those pairs can be accessed through macros. This is just like the way `trigger_dag -c` works [1].

Let's walk through an example.

In the airflow CLI we specify a key-value pair.
```
airflow backfill hello_world -s 2018-02-01 -e 2018-02-08 -c '{"text": "some text"}'
```

In the DAG file, I have a `BashOperator` that contains a template command and I want 
{{ dag_run.conf.text }} resolves to the text I passed in CLI. 
```python
templated_command = """
    echo "ds = {{ ds }}"
    echo "prev_ds = {{ macros.datetime.strftime(prev_execution_date, "%Y-%m-%d") }}"
    echo "next_ds = {{ macros.datetime.strftime(next_execution_date, "%Y-%m-%d") }}"
    echo "text_through_conf = {{ dag_run.conf.text }}"
"""

bash_operator = BashOperator(
    task_id='bash_task',
    bash_command=templated_command,
    dag=dag
    )
```
Rendered Bash command in Airflow UI.
<img width="1246" alt="screen shot 2018-05-22 at 4 33 59 pm" src="https://user-images.githubusercontent.com/6065051/40395666-04c41574-5dde-11e8-9ec2-c0312b7203e6.png">

[1] https://airflow.apache.org/cli.html#trigger_dag
