### PR TITLE
[DPTOOLS-597] Abstract S3 location from SQL

### DIFF
--- a/tests/macros/test_utils.py
+++ b/tests/macros/test_utils.py
@@ -1,0 +1,28 @@
+from mock import patch
+import os
+import unittest
+
+from airflow.macros import s3_location
+
+
+class TestUtils(unittest.TestCase):
+
+    @patch.dict(os.environ, {'SERVICE_INSTANCE': 'development'})
+    def test_s3_location_in_local(self):
+        assert s3_location('test_schema', 'test_table') == 'file:/tmp/hive-warehouse/' \
+                                                           'PRODUCTION/test_schema/test_table'
+
+    @patch.dict(os.environ, {'SERVICE_INSTANCE': 'production'})
+    def test_s3_location_in_prod(self, ):
+        assert s3_location('test_schema', 'test_table') == 's3://lyftqubole-iad/qubole/t/stfihs/' \
+                                                           'PRODUCTION/{schema}/table_name={table}'\
+            .format(schema='test_schema',
+                    table='test_table')
+
+    @patch.dict(os.environ, {'SERVICE_INSTANCE': 'production'})
+    def test_s3_location_for_intermediate_table(self):
+        assert s3_location('test_schema', 'test_table', is_dest=False) \
+            == 's3://lyftqubole-iad/qubole/t/stfihs/' \
+               'PRODUCTION/{schema}/table_name={table}_{{ ds_nodash }}'\
+            .format(schema='test_schema',
+                    table='test_table')


### PR DESCRIPTION
Airflow retrieves all the context for jinja template in https://github.com/apache/incubator-airflow/blob/master/airflow/models.py#L1820-L1851 . Hence we could have two options:
1. we put all the marcos in airflow.macros.__init__.py
2. we put in etl repo, but pass the context translation through params input argument(https://github.com/apache/incubator-airflow/blob/master/airflow/models.py#L2284) for baseOperator