### PR TITLE
[DPTOOLS-599] param can be overridden through CLI

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -180,6 +180,10 @@ security =
 # values at runtime)
 unit_test_mode = False
 
+# Whether to override params with dag_run.conf. If you pass some key-value pairs through `airflow backfill -c` or
+# `airflow trigger_dag -c`, the key-value pairs will override the existing ones in params.
+dag_run_conf_overrides_params = False
+
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
 # database directly, while the json_client will use the api running on the

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1525,6 +1525,9 @@ class TaskInstance(Base):
         if task.params:
             params.update(task.params)
 
+        if configuration.getboolean('core', 'dag_run_conf_overrides_params') and dag_run and dag_run.conf:
+            params.update(dag_run.conf)
+
         class VariableAccessor:
             """
             Wrapper around Variable. This way you can get variables in templates by using

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -138,7 +138,8 @@ Variable                            Description
 ``{{ end_date }}``                  same as ``{{ ds }}``
 ``{{ latest_date }}``               same as ``{{ ds }}``
 ``{{ ti }}``                        same as ``{{ task_instance }}``
-``{{ params }}``                    a reference to the user-defined params dictionary
+``{{ params }}``                    a reference to the user-defined params dictionary which can be overridden by
+                                    the dictionary passed through ``trigger_dag -c`` or ``backfill -c``
 ``{{ var.value.my_var }}``          global defined variables represented as a dictionary
 ``{{ var.json.my_var.path }}``      global defined variables represented as a dictionary
                                     with deserialized JSON object, append the path to the


### PR DESCRIPTION
params can be overridden by the dictionary passed through `airflow backfill -c`

```
templated_command = """
    echo "text = {{ params.text }}"
"""

bash_operator = BashOperator(
    task_id='bash_task',
    bash_command=templated_command,
    dag=dag,
    params= {
        "text" : "normal processing"
    })
```

In daily processing it prints:
```
normal processing
```

In backfill processing `airflow backfill -c "{"text": "backfill processing"}"`, it prints 
```
backfill processing
```