### PR TITLE
QuboleOperator cluster_label templatizable

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -117,7 +117,7 @@ class QuboleOperator(BaseOperator):
                        'extract_query', 'boundary_query', 'macros', 'name', 'parameters',
                        'dbtap_id', 'hive_table', 'db_table', 'split_column', 'note_id',
                        'db_update_keys', 'export_dir', 'partition_spec', 'qubole_conn_id',
-                       'arguments', 'user_program_arguments')
+                       'arguments', 'user_program_arguments', 'cluster_label')
 
     template_ext = ('.txt',)
     ui_color = '#3064A1'


### PR DESCRIPTION
Make `cluster_label` a templatizable field in `QuboleOperator` so that we can override cluster_label in https://github.com/lyft/etl/blob/cad545eba186447f4eeba730e90c9a22115bdb26/sql/hive/core/fact_ride_route_line_items.py through CLI.

