### PR TITLE
Cherry pick change to make backfill logs quieter

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -172,7 +172,9 @@ def backfill(args, dag=None):
             ignore_first_depends_on_past=args.ignore_first_depends_on_past,
             ignore_task_deps=args.ignore_dependencies,
             pool=args.pool,
-            conf=run_conf)
+            conf=run_conf,
+            verbose=args.verbose,
+        )
 
 
 @cli.action_logging
@@ -1280,6 +1282,9 @@ class CLIFactory(object):
         'mark_success': Arg(
             ("-m", "--mark_success"),
             "Mark jobs as succeeded without running them", "store_true"),
+        'verbose': Arg(
+            ("-v", "--verbose"),
+            "Make logging output more verbose", "store_true"),
         'local': Arg(
             ("-l", "--local"),
             "Run the task using the LocalExecutor", "store_true"),
@@ -1568,7 +1573,8 @@ class CLIFactory(object):
                 'dag_id', 'task_regex', 'start_date', 'end_date',
                 'mark_success', 'local', 'donot_pickle', 'include_adhoc',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
-                'subdir', 'pool', 'dry_run', 'conf')
+                'subdir', 'pool', 'dry_run', 'conf', 'verbose',
+            )
         }, {
             'func': list_tasks,
             'help': "List the tasks within a DAG",

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1678,6 +1678,7 @@ class BackfillJob(BaseJob):
             ignore_task_deps=False,
             pool=None,
             conf=None,
+            verbose=False,
             *args, **kwargs):
         self.dag = dag
         self.dag_id = dag.dag_id
@@ -1690,6 +1691,7 @@ class BackfillJob(BaseJob):
         self.ignore_task_deps = ignore_task_deps
         self.pool = pool
         self.conf = conf
+        self.verbose = verbose
         super(BackfillJob, self).__init__(*args, **kwargs)
 
     def _update_counters(self, started, succeeded, skipped, failed, tasks_to_run):
@@ -1948,7 +1950,7 @@ class BackfillJob(BaseJob):
                     if ti.are_dependencies_met(
                             dep_context=backfill_context,
                             session=session,
-                            verbose=True):
+                            verbose=self.verbose):
                         ti.refresh_from_db(lock_for_update=True, session=session)
                         if ti.state == State.SCHEDULED or ti.state == State.UP_FOR_RETRY:
                             if executor.has_task(ti):
@@ -2068,11 +2070,11 @@ class BackfillJob(BaseJob):
                 t.are_dependencies_met(
                     dep_context=DepContext(ignore_depends_on_past=False),
                     session=session,
-                    verbose=True) !=
+                    verbose=self.verbose) !=
                 t.are_dependencies_met(
                     dep_context=DepContext(ignore_depends_on_past=True),
                     session=session,
-                    verbose=True)
+                    verbose=self.verbose)
                 for t in deadlocked)
             if deadlocked_depends_on_past:
                 err += (

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -707,7 +707,7 @@ class DagPickle(Base):
         self.pickle = dag
 
 
-class TaskInstance(Base):
+class TaskInstance(Base, LoggingMixin):
     """
     Task instances store the state of a task instance. This table is the
     authority and single source of truth around what tasks have run and the
@@ -1115,7 +1115,7 @@ class TaskInstance(Base):
         """
         dep_context = dep_context or DepContext()
         failed = False
-        verbose_aware_logger = self.log.info if verbose else self.log.debug
+        verbose_aware_logger = self.logger.info if verbose else self.logger.debug
         for dep_status in self.get_failed_dep_statuses(
                 dep_context=dep_context,
                 session=session):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1109,25 +1109,27 @@ class TaskInstance(Base):
         :type dep_context: DepContext
         :param session: database session
         :type session: Session
-        :param verbose: whether or not to print details on failed dependencies
+        :param verbose: whether log details on failed dependencies on
+            info or debug log level
         :type verbose: boolean
         """
         dep_context = dep_context or DepContext()
         failed = False
+        verbose_aware_logger = self.log.info if verbose else self.log.debug
         for dep_status in self.get_failed_dep_statuses(
                 dep_context=dep_context,
                 session=session):
             failed = True
-            if verbose:
-                logging.info("Dependencies not met for {}, dependency '{}' FAILED: {}"
-                             .format(self, dep_status.dep_name, dep_status.reason))
+
+            verbose_aware_logger(
+                "Dependencies not met for %s, dependency '%s' FAILED: %s",
+                self, dep_status.dep_name, dep_status.reason
+            )
 
         if failed:
             return False
 
-        if verbose:
-            logging.info("Dependencies all met for {}".format(self))
-
+        verbose_aware_logger("Dependencies all met for %s", self)
         return True
 
     @provide_session
@@ -3409,6 +3411,7 @@ class DAG(BaseDag, LoggingMixin):
             ignore_first_depends_on_past=False,
             pool=None,
             conf=None,
+            verbose=False,
     ):
         """
         Runs the DAG.
@@ -3430,6 +3433,7 @@ class DAG(BaseDag, LoggingMixin):
             ignore_first_depends_on_past=ignore_first_depends_on_past,
             pool=pool,
             conf=conf,
+            verbose=verbose,
         )
         job.run()
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apache/incubator-airflow/pull/3414 to address https://issues.apache.org/jira/browse/AIRFLOW-2520. The effect is to get rid of messages like these from the backfill command's output, unless the `-v` flag is specified:

        [2018-06-06 15:03:51,932] {models.py:1126} INFO - Dependencies not met
        for <TaskInstance: long_running_test.sleep_2 2018-01-01 00:00:00
        [scheduled]>, dependency 'Trigger Rule' FAILED: Task's trigger rule
        'all_success' requires all upstream tasks to have succeeded, but found 1
        non-success(es). upstream_tasks_state={'successes': 0L, 'failed': 0L,
        'upstream_failed': 0L, 'skipped': 0L, 'done': 0L},
        upstream_task_ids=['sleep_1']
        [2018-06-06 15:03:51,940] {models.py:1126} INFO - Dependencies not met
        for <TaskInstance: long_running_test.sleep_2 2018-01-03 00:00:00
        [scheduled]>, dependency 'Trigger Rule' FAILED: Task's trigger rule
        'all_success' requires all upstream tasks to have succeeded, but found 1
        non-success(es). upstream_tasks_state={'successes': 0L, 'failed': 0L,
        'upstream_failed': 0L, 'skipped': 0L, 'done': 0L},
        upstream_task_ids=['sleep_1']


cc @lyft/dp-tools-viz 