### PR TITLE
Fix bug when setting task instance state

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2466,7 +2466,7 @@ class TaskInstanceModelView(ModelViewOnly):
             TI = models.TaskInstance
             count = len(ids)
             for id in ids:
-                task_id, dag_id, execution_date = id.split(',')
+                task_id, dag_id, execution_date = iterdecode(id)
                 execution_date = datetime.strptime(execution_date, '%Y-%m-%d %H:%M:%S')
                 ti = session.query(TI).filter(TI.task_id == task_id,
                                               TI.dag_id == dag_id,
@@ -2486,7 +2486,7 @@ class TaskInstanceModelView(ModelViewOnly):
             TI = models.TaskInstance
             count = 0
             for id in ids:
-                task_id, dag_id, execution_date = id.split(',')
+                task_id, dag_id, execution_date = iterdecode(id)
                 execution_date = datetime.strptime(execution_date, '%Y-%m-%d %H:%M:%S')
                 count += session.query(TI).filter(TI.task_id == task_id,
                                                   TI.dag_id == dag_id,


### PR DESCRIPTION
Pull in this change [1] from upstream. Original commit message follows:

When there is a dot in a task's ID or in its execution date, changing
its state from the UI fails.

The reason for this is that Flask-Admin's iterencode function encodes
composite primary keys using dot as the escape symbol. If there is
already a dot in any of the values, it is doubled.

On decoding however, Airflow is currently just splitting the string on a
comma.

This PR switches to using Flask-Admin's iterdecode to correctly decode
task instance rowids when they contain a dot.

[1] https://github.com/apache/incubator-airflow/commit/a27bd620d97950773c7732908eb3c597315fdd0e

cc @lyft/dp-tools-viz 