### PR TITLE
Fix bug in argparse spec for run command

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1414,7 +1414,7 @@ class CLIFactory(object):
         'ignore_all_dependencies': Arg(
             ("-A", "--ignore_all_dependencies"),
             "Ignores all non-critical dependencies, including ignore_ti_state and "
-            "ignore_task_deps"
+            "ignore_task_deps",
             "store_true"),
         # TODO(aoen): ignore_dependencies is a poor choice of name here because it is too
         # vague (e.g. a task being in the appropriate state to be run is also a dependency


### PR DESCRIPTION
The string "store_true" was getting squashed into the help text of the
command because of this missing comma - it's actually supposed to be the
third argument (parameter name: "action").

Upstream fix: https://github.com/apache/incubator-airflow/commit/e88ecff6ac71758d763dd5037b177e7a2fbc9896

cc @lyft/dp-tools-viz 