### PR TITLE
[DPTOOLS-708] Airflow UI needs to gracefully handle DAGs that raise E…

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -272,6 +272,9 @@ dag_orientation = LR
 # privacy.
 demo_mode = False
 
+# Only shows the DAG import errors on the webserver side.
+show_web_server_dag_import_errors_only = False
+
 # The amount of time (in secs) webserver will wait for initial handshake
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -264,6 +264,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                 try:
                     m = imp.load_source(mod_name, filepath)
                     mods.append(m)
+                    if filepath in self.import_errors:
+                        self.import_errors.pop(filepath)
                 except Exception as e:
                     self.logger.exception("Failed to import: " + filepath)
                     self.import_errors[filepath] = str(e)
@@ -297,6 +299,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                         sys.path.insert(0, filepath)
                         m = importlib.import_module(mod_name)
                         mods.append(m)
+                        if filepath in self.import_errors:
+                            self.import_errors.pop(filepath)
                     except Exception as e:
                         self.logger.exception("Failed to import: " + filepath)
                         self.import_errors[filepath] = str(e)

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -213,6 +213,7 @@
     {% else %}
     <a href="/admin/?showPaused=True">Show Paused DAGs</a>
     {% endif %}
+    <a href="{{ url_for("airflow.refresh_all") }}">Refresh All DAGs</a>
   </div>
 {% endblock %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1916,11 +1916,24 @@ class HomeView(AdminIndexView):
                     in sql_query
                     .all()}
 
-        import_errors = session.query(models.ImportError).all()
-        for ie in import_errors:
-            flash(
-                "Broken DAG: [{ie.filename}] {ie.stacktrace}".format(ie=ie),
-                "error")
+        broken_dags_message = 'Broken DAG: [{filename}] {stacktrace} error'
+        if conf.getboolean('webserver', 'show_web_server_dag_import_errors_only'):
+            for filename, stacktrace in dagbag.import_errors.items():
+                flash(
+                    broken_dags_message.format(
+                        filename=filename,
+                        stacktrace=stacktrace,
+                    )
+                )
+        else:
+            import_errors = session.query(models.ImportError).all()
+            for ie in import_errors:
+                flash(
+                    broken_dags_message.format(
+                        filename=ie.filename,
+                        stacktrace=ie.stacktrace,
+                    )
+                )
         session.expunge_all()
         session.commit()
         session.close()


### PR DESCRIPTION
- In webserver only mode, UI shows DAG import errors encountered on the webserver side.
- Add a button to reload the dagbag.

**Details:**
In a normal setup where we have webserver and scheduler running side by side, we won't have this issue. When scheduler cannot import a DAG, it will save the (filepath, stacktrace) into the database and webserver queries the db and show the import error if any. However, since we are running webserver only on TARS, the ImportError table is always empty in db. Thus, this PR allows the webserver to show the import error on webserver side.

<img width="1681" alt="screen shot 2018-06-29 at 3 00 29 pm" src="https://user-images.githubusercontent.com/6065051/42116682-3f3a0f6e-7bad-11e8-86fd-12097fbaf057.png">
