### PR TITLE
[DPTOOLS-748] Resetting DAG runs should allow selecting certain tasks

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -167,7 +167,7 @@ def backfill(args, dag=None):
                 start_date=args.start_date,
                 end_date=args.end_date,
                 confirm_prompt=True,
-                include_subdags=False,
+                include_subdags=True,
             )
 
         dag.run(


### PR DESCRIPTION
FYI:
https://jira.lyft.net/browse/DPTOOLS-748
https://github.com/apache/incubator-airflow/pull/3579

Now user gives -t "task_regex" -i (ignore_dependency) to only reset certain task state.