### PR TITLE
[DPTOOLS-733] airflow pools CLI remove undefined existing pools

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -259,39 +259,63 @@ def pools(args):
     :param args: parsed args object with a property of filepath to airflow pools yaml file
     :return: None
     """
+    session = settings.Session()
     with open(args.filepath, 'r') as stream:
         try:
             pools_config = yaml.load(stream)
         except yaml.YAMLError:
+            print("Failed to load: {}".format(args.filepath))
             print(traceback.format_exc())
             return
+    _pools(session, pools_config)
+    session.close()
 
-    session = settings.Session()
-    existing_pools = (
-        session.query(Pool)
-            .filter(Pool.pool.in_(pools_config.keys()))
-            .all())
-    for current_pool in existing_pools:
-        input_pool_slots = pools_config.get(current_pool.pool).get('slot_counts', 3)
-        input_pool_desc = pools_config.get(current_pool.pool).get('description', '')
-        if int(input_pool_slots) != int(current_pool.slots) or input_pool_desc != current_pool.description:
-            print("Need to update pool: {}".format(current_pool.pool))
-            print("Original slots: {}\nNew slots: {}".format(current_pool.slots, input_pool_slots))
-            print("Original description: {}\nNew description: {}".format(current_pool.description, input_pool_desc))
-            current_pool.slots = input_pool_slots
-            current_pool.description = input_pool_desc
+
+def _pools(session, pools_config):
+    existing_pools = {p.pool: p for p in session.query(Pool).all()}
+
+    # delete existing airflow pools not defined in configuration
+    pools_to_delete = []
+    for pool_name, _pool in existing_pools.items():
+        if pool_name not in pools_config:
+            pools_to_delete.append(_pool)
+
+    # update airflow pools if not existing or slot/description changed
+    pools_to_update = []
+    for pool_name_config in pools_config:
+        pool_slots_config = pools_config.get(pool_name_config).get('slot_counts', 3)
+        pool_desc_config = pools_config.get(pool_name_config).get('description', '')
+        if pool_name_config not in existing_pools:
+            pools_to_update.append(
+                Pool(
+                    pool=pool_name_config,
+                    slots=int(pool_slots_config),
+                    description=pool_desc_config,
+                )
+            )
+            continue
+
+        existing_pool = existing_pools.get(pool_name_config)
+        if int(pool_slots_config) != int(existing_pool.slots) or pool_desc_config != existing_pool.description:
+            print("Need to update pool: {}".format(existing_pool.pool))
+            print("Original slots: {}\nNew slots: {}".format(existing_pool.slots, pool_slots_config))
+            print("Original description: {}\nNew description: {}".format(existing_pool.description, pool_desc_config))
+            existing_pool.slots = pool_slots_config
+            existing_pool.description = pool_desc_config
+            pools_to_update.append(
+                existing_pool
+            )
         else:
-            print("No need to update pool: {}".format(current_pool.pool))
-        del pools_config[current_pool.pool]
+            print("No need to update pool: {}".format(existing_pool.pool))
 
-    for pool_name, pool_slots_and_description in pools_config.iteritems():
-        print("Need to add pool: {}".format(pool_name))
-        session.add(
-            Pool(
-                pool=pool_name,
-                slots=int(pool_slots_and_description.get('slot_counts')),
-                description=pool_slots_and_description.get('description'))
-        )
+    for pool_to_update in pools_to_update:
+        print("Need to update pool: {}".format(pool_to_update))
+        session.add(pool_to_update)
+
+    for pool_to_delete in pools_to_delete:
+        print("Remove undefined pool: {}".format(pool_to_delete.pool))
+        session.delete(pool_to_delete)
+
     session.commit()
 
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -261,12 +261,7 @@ def pools(args):
     """
     session = settings.Session()
     with open(args.filepath, 'r') as stream:
-        try:
-            pools_config = yaml.load(stream)
-        except yaml.YAMLError as e:
-            print("Failed to load: {}".format(args.filepath))
-            print(traceback.format_exc())
-            raise e
+        pools_config = yaml.load(stream)
     _pools(session, pools_config)
     session.close()
 
@@ -309,7 +304,7 @@ def _pools(session, pools_config):
             print("No need to update pool: {}".format(existing_pool.pool))
 
     for pool_to_update in pools_to_update:
-        print("Need to update pool: {}".format(pool_to_update))
+        print("Need to add/update pool: {}".format(pool_to_update))
         session.add(pool_to_update)
 
     for pool_to_delete in pools_to_delete:

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -263,10 +263,10 @@ def pools(args):
     with open(args.filepath, 'r') as stream:
         try:
             pools_config = yaml.load(stream)
-        except yaml.YAMLError:
+        except yaml.YAMLError as e:
             print("Failed to load: {}".format(args.filepath))
             print(traceback.format_exc())
-            return
+            raise e
     _pools(session, pools_config)
     session.close()
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -40,7 +40,7 @@ from tests.test_utils.fake_datetime import FakeDatetime
 
 configuration.load_test_config()
 from airflow import jobs, models, DAG, utils, macros, settings, exceptions
-from airflow.models import BaseOperator
+from airflow.models import BaseOperator, Pool
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
@@ -62,6 +62,7 @@ from airflow.exceptions import AirflowException
 from airflow.configuration import AirflowConfigException
 
 import six
+import tempfile
 
 NUM_EXAMPLE_DAGS = 18
 DEV_NULL = '/dev/null'
@@ -1052,6 +1053,61 @@ class CliTests(unittest.TestCase):
         self.dagbag = models.DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         # Persist DAGs
+
+    def test_pools_add_pool_if_not_exist(self):
+        session = mock.MagicMock()
+        session.add = mock.MagicMock()
+
+        pools_config = {
+            'pool1': {
+                'slot_counts': 1,
+                'description': 'haha',
+            }
+        }
+
+        cli._pools(session, pools_config)
+
+        self.assertEqual('pool1', session.add.call_args_list[0][0][0].pool)
+
+    def test_pools_delete_pool_if_not_defined(self):
+        session = mock.MagicMock()
+        session.delete = mock.MagicMock()
+        query = session.query.return_value
+        query.all.return_value = [
+            Pool(
+                pool='pool1',
+                slots=1,
+                description='desc',
+            )
+        ]
+
+        cli._pools(session, {})
+
+        self.assertEqual('pool1', session.delete.call_args_list[0][0][0].pool)
+
+    def test_pools_update_pool_if_value_changes(self):
+        session = mock.MagicMock()
+        session.add = mock.MagicMock()
+        query = session.query.return_value
+        query.all.return_value = [
+            Pool(
+                pool='pool1',
+                slots=1,
+                description='desc',
+            )
+        ]
+
+        pools_config = {
+            'pool1': {
+                'slot_counts': 1,
+                'description': 'haha',
+            }
+        }
+
+        cli._pools(session, pools_config)
+
+        self.assertEqual('pool1', session.add.call_args_list[0][0][0].pool)
+        self.assertEqual('haha', session.add.call_args_list[0][0][0].description)
 
     def test_cli_list_dags(self):
         args = self.parser.parse_args(['list_dags', '--report'])


### PR DESCRIPTION
When you run
```
airflow pool -f file/path/to/yaml
```
- existing airflow pools not defined in yaml will be removed.
- airflow pools defined in yaml will be added if not exist.
- pool properties changes will be reflected.
