### PR TITLE
Upgrade announcement ui

### DIFF
--- a/airflow/www/static/feed.js
+++ b/airflow/www/static/feed.js
@@ -27,54 +27,43 @@
 // reference them
 
 // FIXME: Change to prod before pushing
-var DP_ANNOUNCEMENTS_FEED_URL = "https://dataplatformadmin.lyft.net/announcements.atom"
+var DP_ANNOUNCEMENTS_FEED_URL = "https://dataplatformadmin.lyft.net/announcements.atom";
 
 var setCss = function(el, attrs) {
     el.setAttribute("style", attrs.join('; '));
-}
+};
 
 var getXmlElementValue = function(el, node) {
     return el.getElementsByTagName(node)[0].firstChild.nodeValue;
-}
+};
 
 var onLoadRssEntries = function() {
     var xmlDoc = this.responseXML;
     var entries = Array.from(xmlDoc.getElementsByTagName("entry"));
     var latestEntry = entries[0];
 
-    var rssContainer = document.getElementById("rss-entries");
+    var external_link = document.getElementById("announcementsLink");
+    var title_box = document.getElementById("announcementHeader");
+    var modal_title = document.getElementById("announcementModalTitle");
+    var modal_body = document.getElementById("announcementBody");
+
     var title = getXmlElementValue(latestEntry, "title");
+    var summary = getXmlElementValue(latestEntry, "summary");
+    var body = getXmlElementValue(latestEntry, "content");
 
-    var entryUrl = (latestEntry.getElementsByTagName("link")[0]).getAttribute("href");
-    var titleNode = document.createElement("a");
-    titleNode.setAttribute("href", entryUrl);
-    titleNode.appendChild(document.createTextNode(title));
 
-    var rssIcon = document.createElement("img");
-    rssIcon.setAttribute("src", "../static/rss-logo.png");
-    setCss(rssIcon, ["float:right"])
-
-    var rssLink = document.createElement("a");
-    rssLink.setAttribute("href", DP_ANNOUNCEMENTS_FEED_URL);
-    rssLink.appendChild(rssIcon);
-
-    rssContainer.appendChild(titleNode);
-    rssContainer.appendChild(rssLink);
-    setCss(rssContainer, ["border:1px",
-                          "border-style:solid",
-                          "min-width:350px",
-                          "max-width:600px",
-                          "float:right",
-                          "padding:2px",
-                          "background-color:linen"]);
-}
+    external_link.setAttribute('href', DP_ANNOUNCEMENTS_FEED_URL);
+    title_box.innerHTML = title;
+    modal_title.innerHTML = summary;
+    modal_body.innerHTML = body;
+};
 
 var populateRssFeed = function() {
     var oReq = new XMLHttpRequest();
     oReq.addEventListener("load", onLoadRssEntries);
     oReq.open("GET", DP_ANNOUNCEMENTS_FEED_URL);
     oReq.send();
-}
+};
 
 document.addEventListener("DOMContentLoaded", function(event) {
     populateRssFeed();

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -23,17 +23,35 @@
 {{ super() }}
 <link href="{{ url_for("static", filename="dataTables.bootstrap.css") }}" rel="stylesheet" type="text/css" >
 <link href="{{ url_for("static", filename="bootstrap-toggle.min.css") }}" rel="stylesheet" type="text/css">
+<link href="{{ url_for("static", filename="bootstrap-toggle.min.css") }}" rel="stylesheet" type="text/css">
 
-{% if request.args.get('show_rss') in ('1', 'true', 'True') %}
-<script src="/static/feed.js"></script>
-{% endif %}
+<script src="{{ url_for('static', filename='feed.js') }}"></script>
 {% endblock %}
 
 
 {% block body %}
-  {% if request.args.get('show_rss') in ('1', 'true', 'True') %}
-  <div id="rss-entries" style="max-width:500px"></div>
-  {% endif %}
+  <div class=" announcement btn-group" role="group" aria-label="Basic example" style="float: right">
+  <button type="button" class="announcement btn btn-primary" data-toggle="modal" data-target="#announcementModal" id="announcementHeader">
+  </button>
+      <a href="#" class=" announcement btn btn-primary" id="announcementsLink">
+        <img src="{{ url_for("static", filename="rss-logo.png") }}" /> See More
+      </a>
+  </div>
+  <!-- Modal -->
+  <div class="modal fade" id="announcementModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="announcementModalTitle"></h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="announcementBody">
+        </div>
+      </div>
+    </div>
+  </div>
 
   <h2>DAGs</h2>
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -42,10 +42,10 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="announcementModalTitle"></h5>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
+          <h5 class="modal-title" id="announcementModalTitle"></h5>
         </div>
         <div class="modal-body" id="announcementBody">
         </div>


### PR DESCRIPTION
Show a little button on the Airflow UI to show Announcements:
<img width="985" alt="screenshot 2018-07-31 14 10 14" src="https://user-images.githubusercontent.com/3519697/43487528-c7ddc2e8-94cb-11e8-95de-a2430bfd3da4.png">

With modal capabilities
<img width="991" alt="screenshot 2018-07-31 14 10 30" src="https://user-images.githubusercontent.com/3519697/43487529-c7f1a4a2-94cb-11e8-8baf-aca364f2c79a.png">

Links to the atom feed for dataplatformadmin

I want to use this to announce @TirathPatel new feature: 
https://github.com/lyft/etl/pull/11510