### PR TITLE
Configure global extra links for every operator through plugin

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1952,10 +1952,22 @@ class BaseOperator(object):
 
     # For derived classes to define which fields will get jinjaified
     template_fields = []
-    # Defines wich files extensions to look for in the templated fields
+    # Defines which files extensions to look for in the templated fields
     template_ext = []
-    # Defines the extra buttons to display in the task instance model view
-    extra_links = []
+    # Defines which function to call per button
+    # key is the name of the button, which is a string
+    # value is the function to call to get the URL corresponding to the button
+    # The function should follow this format:
+    # type: (BaseOperator, datetime) -> str
+    extra_link_functions = {}
+
+    @property
+    def extra_links(self):
+        """
+        :return: a list of extra buttons to display in the task instance model view
+        """
+        return list(self.extra_link_functions)
+
     # Defines the color in the UI
     ui_color = '#fff'
     ui_fgcolor = '#000'
@@ -2598,18 +2610,6 @@ class BaseOperator(object):
             dag_id=dag_id,
             include_prior_dates=include_prior_dates)
 
-    def get_extra_links(self, dttm, link_name):
-        """
-        For an operator, gets the URL that the external links specified in
-        `extra_links` should point to.
-        :raise ValueError: The error message of a ValueError will be passed on through to
-            the fronted to show up as a tooltip on the disabled link
-        :param dttm: The datetime parsed execution date for the URL being searched for
-        :param link_name: The name of the link we're looking for the URL for. Should be
-            one of the options specified in `extra_links`
-        :return: A URL
-        """
-        pass
 
 class DagModel(Base):
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1780,11 +1780,11 @@ class Airflow(BaseView):
             response.status_code = 404
             return response
 
-
         task = dag.get_task(task_id)
 
         try:
-            url = task.get_extra_links(dttm, link_name)
+            link_func = task.extra_link_functions[link_name]
+            url = link_func(task, dttm)
         except ValueError as err:
             response = jsonify({'url': None, 'error': str(err)})
             response.status_code = 404

--- a/tests/models.py
+++ b/tests/models.py
@@ -289,13 +289,14 @@ class DagTest(unittest.TestCase):
         result = task.render_template('', "{{ 'world' | hello}}", dict())
         self.assertEqual(result, 'Hello world')
 
-    def test_extra_links_no_affect(self):
+    def test_extra_links_registered_in_test_plugin(self):
         """
-        test for no affect on existing operators with no extra_links
+        test that extra links registered in test plugin is available.
         """
         task = DummyOperator(task_id="some_dummy_task")
-        self.assertEqual(task.extra_links, [])
-        self.assertEqual(task.get_extra_links(DEFAULT_DATE, 'foo-bar'), None)
+        self.assertEqual(task.extra_links, ['Extra link'])
+        extra_link_func = task.extra_link_functions['Extra link']
+        self.assertEqual(extra_link_func(task, DEFAULT_DATE), 'i am lost')
 
     def test_extra_links(self):
         """
@@ -303,14 +304,14 @@ class DagTest(unittest.TestCase):
         """
         class DummyTestOperator(BaseOperator):
             extra_links = ['foo-bar']
-
-            def get_extra_links(self, ddtm, link_name):
-                return('www.foo-bar.com')
+            extra_link_functions = {
+                'foo-bar': lambda dttm, link_name: 'www.foo-bar.com',
+            }
 
         task = DummyTestOperator(task_id="some_dummy_task")
         self.assertEqual(task.extra_links, ['foo-bar'])
-        self.assertEqual(task.get_extra_links(DEFAULT_DATE, 'foo-bar'),
-                         'www.foo-bar.com')
+        extra_link_func = task.extra_link_functions['foo-bar']
+        self.assertEqual(extra_link_func(task, DEFAULT_DATE), 'www.foo-bar.com')
 
 
 class DagStatTest(unittest.TestCase):

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -60,6 +60,7 @@ ml = MenuLink(
     name='Test Menu Link',
     url='http://pythonhosted.org/airflow/')
 
+
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
@@ -70,3 +71,7 @@ class AirflowTestPlugin(AirflowPlugin):
     admin_views = [v]
     flask_blueprints = [bp]
     menu_links = [ml]
+    # A button in every Airflow operator that will redirect you to other places.
+    extra_links = {
+        'Extra link': lambda task, dttm: 'i am lost',
+    }

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -100,13 +100,17 @@ class TestExtraLinks(unittest.TestCase):
         class DummyTestOperator(BaseOperator):
             extra_links = ['foo-bar']
 
-            def get_extra_links(self, ddtm, link_name):
-                if link_name == 'raise_error':
-                    raise ValueError('This is an error')
-                if link_name == 'no_response':
-                    return None
-                return 'http://www.example.com/{0}/{1}/{2}'.format(self.task_id,
-                                                                   link_name, ddtm)
+            def foo_bar(self, dttm):
+                return 'http://www.example.com/{0}/{1}/{2}'.format(self.task_id, 'foo-bar', dttm)
+
+            def raise_error(self, dttm):
+                raise ValueError('This is an error')
+
+            extra_link_functions = {
+                'foo-bar': foo_bar,
+                'raise_error': raise_error,
+                'no_response': lambda task, dttm: None,
+            }
 
         self.dag = DAG('dag', start_date=self.DEFAULT_DATE)
         self.task = DummyTestOperator(task_id="some_dummy_task", dag=self.dag)


### PR DESCRIPTION
Put extra links in plugin
```
def get_kibana_discover_url(query, days_ago):
    return 'url'

class MyFirstPlugin(AirflowPlugin):
    name = "my_first_plugin"
    extra_links = {
        'Kibana Logs': get_kibana_discover_url_for_task,
    }
```

and `Kibana Logs` button will be available for all operators.

To register button for individual operator:
```
class MyFirstOperator(BaseOperator):

    @apply_defaults
    def __init__(self, my_operator_param, *args, **kwargs):
        self.operator_param = my_operator_param
        super(MyFirstOperator, self).__init__(*args, **kwargs)

    def execute(self, context):
        log.info("Hello World!")
        log.info('operator_param: %s', self.operator_param)

    extra_links = ['Qubole logs']
    
    extra_link_functions = {
        'Qubole logs': lambda task, dttm: "qubole!"
    }
```

and `Kibana logs` and `Qubole logs` will be available for `MyFirstOperator`
