### PR TITLE
[DPTOOLS-892] Airflow UI search bar broken

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2006,8 +2006,8 @@ class HomeView(AdminIndexView):
             }
 
             all_dag_ids = (set([dag.dag_id for dag in orm_dags.values()
-                                if lower_search_query in dag.dag_id.lower() or
-                                lower_search_query in dag.owners.lower()]) |
+                                if dag.owners is not None and (lower_search_query in dag.dag_id.lower() or
+                                lower_search_query in dag.owners.lower())]) |
                            set(webserver_dags_filtered.keys()))
 
             sorted_dag_ids = sorted(all_dag_ids)


### PR DESCRIPTION
The issue is because the owners for one of the dag(driver_engagement) in tars is missing. We should skip those dags instead of throwing exceptions.