### PR TITLE
set VariableView to ModelViewOnly

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2316,7 +2316,7 @@ class KnowEventTypeView(wwwutils.DataProfilingMixin, AirflowModelView):
 # admin.add_view(mv)
 
 
-class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
+class VariableView(wwwutils.DataProfilingMixin, ModelViewOnly):
     verbose_name = "Variable"
     verbose_name_plural = "Variables"
     list_template = 'airflow/variable_list.html'


### PR DESCRIPTION
This PR is to set variable view to view only, so our customers will not have write access on Variable table from Airflow UI.