### PR TITLE
log action_logger failure instead of bubling errors up

### DIFF
--- a/airflow/utils/action_loggers.py
+++ b/airflow/utils/action_loggers.py
@@ -36,7 +36,11 @@ class DefaultActionLogger:
 
         session = airflow.settings.Session()
         session.add(log)
-        session.commit()
+        try:
+            session.commit()
+        except Exception as e:
+            logging.warning('Failed to commit action_logs', e)
+            session.rollback()
 
 
 def add(action_logger):


### PR DESCRIPTION
We've been getting Airflow action_logger failures for quite some time. Since there is no operation needed for the transient failure. I suggest that we catch and log the exception as warning instead of letting the exception bubbling up.

We should setup alerts that count the number of action_logger warning and only alert when the number is too high.