### PR TITLE
Raise the exception when encounter UI error

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2607,7 +2607,7 @@ class TaskInstanceModelView(ModelViewOnly):
             ui_signals.send(self, message='set task instance {} - {}'.format(target_state, log_tis))
         except Exception as ex:
             if not self.handle_view_exception(ex):
-                raise Exception("Ooops")
+                raise ex
             flash('Failed to set state', 'error')
 
     @provide_session


### PR DESCRIPTION
Having a oops for exception is not useful. This is for https://jira.lyft.net/projects/DATAHELP/queues/custom/274/DATAHELP-1344