### PR TITLE
[AIRFLOW-4163] IntervalCheckOperator supports relative diff and not i…

### DIFF
--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -15,6 +15,7 @@
 from builtins import zip
 from builtins import str
 import logging
+from typing import Optional, Any, Iterable, Dict, SupportsAbs
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
@@ -179,6 +180,17 @@ class IntervalCheckOperator(BaseOperator):
     :param days_back: number of days between ds and the ds we want to check
         against. Defaults to 7 days
     :type days_back: int
+    :param ratio_formula: which formula to use to compute the ratio between
+        the two metrics. Assuming cur is the metric of today and ref is
+        the metric to today - days_back.
+
+        max_over_min: computes max(cur, ref) / min(cur, ref)
+        relative_diff: computes abs(cur-ref) / ref
+
+        Default: 'max_over_min'
+    :type ratio_formula: str
+    :param ignore_zero: whether we should ignore zero metrics
+    :type ignore_zero: bool
     :param metrics_threshold: a dictionary of ratios indexed by metrics
     :type metrics_threshold: dict
     """
@@ -190,13 +202,33 @@ class IntervalCheckOperator(BaseOperator):
     template_ext = ('.hql', '.sql',)
     ui_color = '#fff7e6'
 
+    ratio_formulas = {
+        'max_over_min': lambda cur, ref: float(max(cur, ref)) / min(cur, ref),
+        'relative_diff': lambda cur, ref: float(abs(cur - ref)) / ref,
+    }
+
     @apply_defaults
     def __init__(
-            self, table, metrics_thresholds,
-            date_filter_column='ds', days_back=-7,
-            conn_id=None,
+            self,
+            table,  # type: str
+            metrics_thresholds,  # type: Dict[str, int]
+            date_filter_column='ds',  # type: Optional[str]
+            days_back=-7,  # type: SupportsAbs[int]
+            ratio_formula='max_over_min',  # type: Optional[str]
+            ignore_zero=True,  # type: Optional[bool]
+            conn_id=None,  # type: Optional[str]
             *args, **kwargs):
         super(IntervalCheckOperator, self).__init__(*args, **kwargs)
+        if ratio_formula not in self.ratio_formulas:
+            msg_template = "Invalid diff_method: {diff_method}. " \
+                           "Supported diff methods are: {diff_methods}"
+
+            raise AirflowException(
+                msg_template.format(diff_method=ratio_formula,
+                                    diff_methods=self.ratio_formulas)
+            )
+        self.ratio_formula = ratio_formula
+        self.ignore_zero = ignore_zero
         self.table = table
         self.metrics_thresholds = metrics_thresholds
         self.metrics_sorted = sorted(metrics_thresholds.keys())
@@ -211,7 +243,8 @@ class IntervalCheckOperator(BaseOperator):
 
     def execute(self, context=None):
         hook = self.get_db_hook()
-        logging.info('Executing SQL check: ' + self.sql2)
+        self.log.info('Using ratio formula: %s', self.ratio_formula)
+        self.log.info('Executing SQL check: %s', self.sql2)
         row2 = hook.get_first(self.sql2)
         logging.info('Executing SQL check: ' + self.sql1)
         row1 = hook.get_first(self.sql1)
@@ -228,24 +261,36 @@ class IntervalCheckOperator(BaseOperator):
         estr = "The following tests have failed:\n {0}"
         countstr = "The following {j} tests out of {n} failed:"
         for m in self.metrics_sorted:
-            if current[m] == 0 or reference[m] == 0:
-                ratio = None
+            cur = current[m]
+            ref = reference[m]
+            threshold = self.metrics_thresholds[m]
+            if cur == 0 or ref == 0:
+                ratios[m] = None
+                test_results[m] = self.ignore_zero
             else:
-                ratio = float(max(current[m], reference[m])) / \
-                    min(current[m], reference[m])
-            logging.info(rlog.format(m, ratio, self.metrics_thresholds[m]))
-            ratios[m] = ratio
-            test_results[m] = ratio < self.metrics_thresholds[m]
+                ratios[m] = self.ratio_formulas[self.ratio_formula](current[m], reference[m])
+                test_results[m] = ratios[m] < threshold
+
+            self.log.info(
+                (
+                    "Current metric for %s: %s\n"
+                    "Past metric for %s: %s\n"
+                    "Ratio for %s: %s\n"
+                    "Threshold: %s\n"
+                ), m, cur, m, ref, m, ratios[m], threshold)
+
         if not all(test_results.values()):
             failed_tests = [it[0] for it in test_results.items() if not it[1]]
             j = len(failed_tests)
             n = len(self.metrics_sorted)
             logging.warning(countstr.format(**locals()))
             for k in failed_tests:
-                logging.warning(fstr.format(k=k, r=ratios[k],
-                                tr=self.metrics_thresholds[k]))
-            raise AirflowException(estr.format(", ".join(failed_tests)))
-        logging.info("All tests have passed")
+                self.log.warning(
+                    "'%s' check failed. %s is above %s", k, ratios[k], self.metrics_thresholds[k]
+                )
+            raise AirflowException("The following tests have failed:\n {0}".format(", ".join(
+                sorted(failed_tests))))
+        self.log.info("All tests have passed")
 
     def get_db_hook(self):
         return BaseHook.get_hook(conn_id=self.conn_id)

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -243,8 +243,8 @@ class IntervalCheckOperator(BaseOperator):
 
     def execute(self, context=None):
         hook = self.get_db_hook()
-        self.log.info('Using ratio formula: %s', self.ratio_formula)
-        self.log.info('Executing SQL check: %s', self.sql2)
+        logging.info('Using ratio formula: %s', self.ratio_formula)
+        logging.info('Executing SQL check: %s', self.sql2)
         row2 = hook.get_first(self.sql2)
         logging.info('Executing SQL check: ' + self.sql1)
         row1 = hook.get_first(self.sql1)
@@ -259,7 +259,7 @@ class IntervalCheckOperator(BaseOperator):
         rlog = "Ratio for {0}: {1} \n Ratio threshold : {2}"
         fstr = "'{k}' check failed. {r} is above {tr}"
         estr = "The following tests have failed:\n {0}"
-        countstr = "The following {j} tests out of {n} failed:"
+        countstr = "The following {j} tests out of {n} fai:qled:"
         for m in self.metrics_sorted:
             cur = current[m]
             ref = reference[m]
@@ -271,7 +271,7 @@ class IntervalCheckOperator(BaseOperator):
                 ratios[m] = self.ratio_formulas[self.ratio_formula](current[m], reference[m])
                 test_results[m] = ratios[m] < threshold
 
-            self.log.info(
+            logging.info(
                 (
                     "Current metric for %s: %s\n"
                     "Past metric for %s: %s\n"
@@ -285,12 +285,12 @@ class IntervalCheckOperator(BaseOperator):
             n = len(self.metrics_sorted)
             logging.warning(countstr.format(**locals()))
             for k in failed_tests:
-                self.log.warning(
+                logging.warning(
                     "'%s' check failed. %s is above %s", k, ratios[k], self.metrics_thresholds[k]
                 )
             raise AirflowException("The following tests have failed:\n {0}".format(", ".join(
                 sorted(failed_tests))))
-        self.log.info("All tests have passed")
+        logging.info("All tests have passed")
 
     def get_db_hook(self):
         return BaseHook.get_hook(conn_id=self.conn_id)

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -259,7 +259,7 @@ class IntervalCheckOperator(BaseOperator):
         rlog = "Ratio for {0}: {1} \n Ratio threshold : {2}"
         fstr = "'{k}' check failed. {r} is above {tr}"
         estr = "The following tests have failed:\n {0}"
-        countstr = "The following {j} tests out of {n} fai:qled:"
+        countstr = "The following {j} tests out of {n} failed:"
         for m in self.metrics_sorted:
             cur = current[m]
             ref = reference[m]

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from datetime import datetime
+from airflow.models import DAG
+from airflow.exceptions import AirflowException
+
+from airflow.operators.check_operator import IntervalCheckOperator, ValueCheckOperator
+from tests.compat import mock
+
+
+class ValueCheckOperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.task_id = 'test_task'
+        self.conn_id = 'default_conn'
+
+    def __construct_operator(self, sql, pass_value, tolerance=None):
+
+        dag = DAG('test_dag', start_date=datetime(2017, 1, 1))
+
+        return ValueCheckOperator(
+            dag=dag,
+            task_id=self.task_id,
+            conn_id=self.conn_id,
+            sql=sql,
+            pass_value=pass_value,
+            tolerance=tolerance)
+
+    def test_pass_value_template_string(self):
+        pass_value_str = "2018-03-22"
+        operator = self.__construct_operator('select date from tab1;', "{{ ds }}")
+        result = operator.render_template('pass_value', operator.pass_value,
+                                          {'ds': pass_value_str})
+
+        self.assertEqual(operator.task_id, self.task_id)
+        self.assertEqual(result, pass_value_str)
+
+    def test_pass_value_template_string_float(self):
+        pass_value_float = 4.0
+        operator = self.__construct_operator('select date from tab1;', pass_value_float)
+        result = operator.render_template('pass_value', operator.pass_value, {})
+
+        self.assertEqual(operator.task_id, self.task_id)
+        self.assertEqual(result, str(pass_value_float))
+
+    @mock.patch.object(ValueCheckOperator, 'get_db_hook')
+    def test_execute_pass(self, mock_get_db_hook):
+
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [10]
+        mock_get_db_hook.return_value = mock_hook
+
+        sql = 'select value from tab1 limit 1;'
+
+        operator = self.__construct_operator(sql, 5, 1)
+
+        operator.execute(None)
+
+        mock_hook.get_first.assert_called_with(sql)
+
+    @mock.patch.object(ValueCheckOperator, 'get_db_hook')
+    def test_execute_fail(self, mock_get_db_hook):
+
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [11]
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self.__construct_operator('select value from tab1 limit 1;', 5, 1)
+
+        with self.assertRaisesRegexp(AirflowException, 'Tolerance:100.0%'):
+            operator.execute()
+
+
+class IntervalCheckOperatorTest(unittest.TestCase):
+
+    def _construct_operator(self, table, metric_thresholds,
+                            ratio_formula, ignore_zero):
+        return IntervalCheckOperator(
+            task_id='test_task',
+            table=table,
+            metrics_thresholds=metric_thresholds,
+            ratio_formula=ratio_formula,
+            ignore_zero=ignore_zero,
+        )
+
+    def test_invalid_ratio_formula(self):
+        with self.assertRaisesRegexp(AirflowException, 'Invalid diff_method'):
+            self._construct_operator(
+                table='test_table',
+                metric_thresholds={
+                    'f1': 1,
+                },
+                ratio_formula='abs',
+                ignore_zero=False,
+            )
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_not_ignore_zero(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [0]
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f1': 1,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=False,
+        )
+
+        with self.assertRaises(AirflowException):
+            operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_ignore_zero(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [0]
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f1': 1,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=True,
+        )
+
+        operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_min_max(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+
+        def returned_row():
+            rows = [
+                [2, 2, 2, 2],  # reference
+                [1, 1, 1, 1],  # current
+            ]
+
+            for r in rows:
+                yield r
+
+        mock_hook.get_first.side_effect = returned_row()
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f0': 1.0,
+                'f1': 1.5,
+                'f2': 2.0,
+                'f3': 2.5,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=True,
+        )
+
+        with self.assertRaisesRegexp(AirflowException, "f0, f1, f2"):
+            operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_diff(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+
+        def returned_row():
+            rows = [
+                [3, 3, 3, 3],  # reference
+                [1, 1, 1, 1],  # current
+            ]
+
+            for r in rows:
+                yield r
+
+        mock_hook.get_first.side_effect = returned_row()
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f0': 0.5,
+                'f1': 0.6,
+                'f2': 0.7,
+                'f3': 0.8,
+            },
+            ratio_formula='relative_diff',
+            ignore_zero=True,
+        )
+
+        with self.assertRaisesRegexp(AirflowException, "f0, f1"):
+            operator.execute()

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -23,7 +23,7 @@ from airflow.models import DAG
 from airflow.exceptions import AirflowException
 
 from airflow.operators.check_operator import IntervalCheckOperator, ValueCheckOperator
-from tests.compat import mock
+from mock import mock
 
 
 class ValueCheckOperatorTest(unittest.TestCase):


### PR DESCRIPTION
Make `IntervalCheckOperator` supports calculating ratio with relative difference. And also add an option to not ignore zero values in metric.

Cherry picked from: https://github.com/apache/airflow/pull/4983