### PR TITLE
Ignore tasks with no duration timestamp set in Tasks Duration page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1432,8 +1432,9 @@ class Airflow(AirflowBaseView):
 
         fails_totals = defaultdict(int)
         for tf in ti_fails:
-            dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
-            fails_totals[dict_key] += tf.duration
+            if tf.duration:
+                dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
+                fails_totals[dict_key] += tf.duration
 
         for ti in tis:
             if ti.duration:


### PR DESCRIPTION
Not all tasks have duration timestamp set. Task duration page throws a 500 error when it encounters such a task. One example : https://airflow.lyft.net/duration?dag_id=dag_coupa_invoice_f&days=30&root= 
This dag has couple of tasks in `upstream_failed` state. 