### PR TITLE
Upgrade Flask Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ def do_setup():
             'blinker==1.4',
             'croniter>=0.3.8, <0.4',
             'dill>=0.2.2, <0.3',
-            'flask>=0.11, <=0.12.1',
+            'flask>=1.0, <2.0',
             'flask-admin>=1.4.1, <=1.5.0',
             'flask-caching>=1.3.3, <1.4.0',
             'flask-login==0.2.11',

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ def do_setup():
             'future>=0.15.0, <0.16',
             'gitpython>=2.0.2',
             # 'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
-            'jinja2>=2.7.3, <=2.9.5',
+            'jinja2>=2.10, <3.0',
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'paramiko>=2.1',


### PR DESCRIPTION
The current flask version 'flask>=0.11, <=0.12.1' is incompatible with that of dependencies in lyft-idl > v3866, - in particular 'flask-protobuf>=0.4.3,<1' requirements of lyft-idl

Ref: https://github.com/lyft/idlcode/blob/d1ff7559f11e6145a020f3031fbae5384cd3dfe2/setup_shared.py#L49

We need to use a newer version of lyft-idl > v3866 in our etl code base. This requires a change to the flask version requirements of apache-airflow.
