### PR TITLE
[AIRFLOW-4251] Instrument DagRun schedule delay (#5050)

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1191,7 +1191,7 @@ class SchedulerJob(BaseJob):
                     Stats.timing(
                         'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
                         schedule_delay)
-                self.log.info("Created %s", dag_run)
+                self.logger.info("Created %s", dag_run)
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1185,7 +1185,13 @@ class SchedulerJob(BaseJob):
 
             dag_run = self.create_dag_run(dag)
             if dag_run:
-                self.logger.info("Created {}".format(dag_run))
+                expected_start_date = dag.following_schedule(dag_run.execution_date)
+                if expected_start_date:
+                    schedule_delay = dag_run.start_date - expected_start_date
+                    Stats.timing(
+                        'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
+                        schedule_delay)
+                self.log.info("Created %s", dag_run)
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
 


### PR DESCRIPTION
Instrument DagRun schedule delay - time between expected DagRun start date and the actual DagRun start date.