### PR TITLE
DagRun stats using ms instead of datetime.timedelta

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1188,7 +1188,7 @@ class SchedulerJob(BaseJob):
                 expected_start_date = dag.following_schedule(dag_run.execution_date)
                 if expected_start_date:
                     schedule_delay = \
-                        (dag_run.start_date - expected_start_date).total_seconds * 1000
+                        (dag_run.start_date - expected_start_date).total_seconds() * 1000
                     Stats.timing(
                         'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
                         schedule_delay)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1187,7 +1187,8 @@ class SchedulerJob(BaseJob):
             if dag_run:
                 expected_start_date = dag.following_schedule(dag_run.execution_date)
                 if expected_start_date:
-                    schedule_delay = dag_run.start_date - expected_start_date
+                    schedule_delay = \
+                        (dag_run.start_date - expected_start_date).total_seconds * 1000
                     Stats.timing(
                         'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
                         schedule_delay)


### PR DESCRIPTION
`Stats.timing` does not support taking `datetime.timedelta`, thus changing it to use `int` (milliseconds)