### PR TITLE
Record the time spent loading each DAG

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -441,6 +441,12 @@ class DagBag(BaseDagBag, LoggingMixin):
         self.dagbag_stats = sorted(
             stats, key=lambda x: x.duration, reverse=True)
 
+        for stat in self.dagbag_stats:
+            parse_duration_millis = stat.duration * 1000
+            dag_file_path = stat.file.lstrip('/')
+            Stats.gauge(
+                'collect_dags.{}'.format(dag_file_path), parse_duration_millis, 1)
+
     def dagbag_report(self):
         """Prints a report around DagBag loading stats"""
         report = textwrap.dedent("""\n


### PR DESCRIPTION
See DATAHELP-2038 [1], in which one of the experimentation DAGs sometimes
disappears from the UI's DagBag. I suspect this is because it
occasionally takes too long to load. These metrics should give us more
visibility into the loading time per DAG.

Verified that the metrics are coming through in onebox [2]

    gauges.airflow.collect_dags.long_running_test_dag.py|321.054000|1561752840
    gauges.airflow.collect_dags.long_running_test_dag.py.sum|321.054000|1561752840
    gauges.airflow.collect_dags.long_running_test_dag.py.mean|321.054000|1561752840
    gauges.airflow.collect_dags.long_running_test_dag.py.min|321.054000|1561752840
    gauges.airflow.collect_dags.long_running_test_dag.py.max|321.054000|1561752840

[1] https://jira.lyft.net/projects/DATAHELP/queues/custom/274/DATAHELP-2038
[2] https://docs.lyft.net/eng/etl/airflow/airflow-concepts.html#exposing-stats-information-in-devbox