### PR TITLE
Fix webserver command for gunicorn v9.6

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -886,7 +886,7 @@ def webserver(args):
             '-b', args.hostname + ':' + str(args.port),
             '-n', 'airflow-webserver',
             '-p', str(pid),
-            '-c', 'airflow.www.gunicorn_config'
+            '-c', 'python:airflow.www.gunicorn_config'
         ]
 
         if args.access_logfile:


### PR DESCRIPTION
We upgraded to gunicorn 9.6 in [1], and the syntax for specifying the config
module changed in gunicorn 9.6 - see [2] for an explanation. This change uses
the new syntax to specify the config as a Python module, not as a file.
Without this change, `airflow webserver` is broken:

    [TARS] ~$ tars_venv airflow webserver --workers=1 -k gevent --port 13001
    /srv/venvs/service/trusty/service_venv/local/lib/python2.7/site-packages/cryptography/hazmat/primitives/constant_time.py:26: CryptographyDeprecationWarning: Support for your Python version is deprecated. The next version of cryptography will remove support. Please upgrade to a 2.7.x release that supports hmac.compare_digest as soon as possible.
      utils.DeprecatedIn23,
    [2019-07-01 17:48:08,311] {__init__.py:57} INFO - Using executor LocalExecutor
    [2019-07-01 17:48:08,541] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
    [2019-07-01 17:48:08,661] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
    [2019-07-01 17:48:10,743] {airflow:40} INFO - Using IP addresses instead of hostnames.
      ____________       _____________
     ____    |__( )_________  __/__  /________      __
    ____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
    ___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
     _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/

    [2019-07-01 17:48:11,412] [113974] {models.py:169} INFO - Filling up the DagBag from /home/astahlman/etl/lib/lyftdata/airflow/dags
    Running the Gunicorn Server with:
    Workers: 1 gevent
    Host: 0.0.0.0:13001
    Timeout: 120
    Logfiles: - -
    =================================================================

    Error: 'airflow.www.gunicorn_config' doesn't exist

Note that this is only needed for TARS - in staging and prod, we
explicitly invoke gunicorn (instead of invoking `airflow web`) and we
pass a gunicorn.conf file, not a Python module [3].

[1] https://github.com/lyft/etl/commit/683388068470bb5a02b3da814708a71f646f31f2
[2] https://www.mail-archive.com/commits@airflow.incubator.apache.org/msg10887.html
[3] https://github.com/lyft/etl/blob/3df02bf3490dc0898360a47ad2505f102bd1bc7e/ops/config/pillar/etlairflowwebserver.sls#L8

cc @lyft/dp-tools-viz 