### PR TITLE
[DATAHELP-2099] Fix find all downstream skippable duplicates

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1854,19 +1854,19 @@ class SkipMixin(object):
 
         return all_downstream
 
-    def find_all_downstream_skippable(self, task, blacklisted_ti_reprs=None):
-        if blacklisted_ti_reprs is None:
-            blacklisted_ti_reprs = set()
+    def find_all_downstream_skippable(self, task, processed_tis_repr=None):
+        if processed_tis_repr is None:
+            processed_tis_repr = set()
 
         immediate_downstream = task.downstream_list
         all_downstream = []
         for downstream_task in immediate_downstream:
             if downstream_task.trigger_rule in ['all_success', 'all_failed'] \
-                    and repr(downstream_task) not in blacklisted_ti_reprs:
+                    and repr(downstream_task) not in processed_tis_repr:
                 all_downstream.append(downstream_task)
-                blacklisted_ti_reprs.add(repr(downstream_task))
+                processed_tis_repr.add(repr(downstream_task))
         for downstream_task in all_downstream:
-            all_downstream.extend(self.find_all_downstream_skippable(downstream_task, blacklisted_ti_reprs))
+            all_downstream.extend(self.find_all_downstream_skippable(downstream_task, processed_tis_repr))
             
         return all_downstream
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1854,14 +1854,19 @@ class SkipMixin(object):
 
         return all_downstream
 
-    def find_all_downstream_skippable(self, task):
+    def find_all_downstream_skippable(self, task, blacklisted_ti_reprs=None):
+        if blacklisted_ti_reprs is None:
+            blacklisted_ti_reprs = set()
+
         immediate_downstream = task.downstream_list
         all_downstream = []
         for downstream_task in immediate_downstream:
-            if downstream_task.trigger_rule in ['all_success', 'all_failed']:
+            if downstream_task.trigger_rule in ['all_success', 'all_failed'] \
+                    and repr(downstream_task) not in blacklisted_ti_reprs:
                 all_downstream.append(downstream_task)
+                blacklisted_ti_reprs.add(repr(downstream_task))
         for downstream_task in all_downstream:
-            all_downstream.extend(self.find_all_downstream_skippable(downstream_task))
+            all_downstream.extend(self.find_all_downstream_skippable(downstream_task, blacklisted_ti_reprs))
             
         return all_downstream
 

--- a/tests/operators/python_operator.py
+++ b/tests/operators/python_operator.py
@@ -193,7 +193,8 @@ class BranchOperatorTest(unittest.TestCase):
         when trying to find skippable downstreams of branch_2
         """
         tasks_to_skip = [t.task_id for t in self.branch_op.find_all_downstream_skippable(self.branch_2)]
-        expected_tasks_id = ['sub_branch_3', 'sub_branch_4', 'sub_branch_5']
+        expected_tasks_id = ['make_choice_skipped', 'sub_branch_1', 'sub_branch_2',
+                             'sub_branch_3', 'sub_branch_4', 'sub_branch_5']
         assert len(tasks_to_skip) == len(expected_tasks_id) and sorted(tasks_to_skip) == sorted(expected_tasks_id)
 
 


### PR DESCRIPTION
This PR is aiming to filter out duplicate TIs when iterating through all downstream tasks.