### PR TITLE
Make airflow conf prefix configurable

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -102,6 +102,11 @@ dags_folder = {AIRFLOW_HOME}/dags
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs
 
+# Connections in Airflow can be created through environment variable.
+# The environment variable need to start with a prefix of conn_env_prefix
+# so that Airflow can pick it up.
+conn_env_prefix = AIRFLOW_CONN_
+
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
 # must supply a remote location URL (starting with either 's3://...' or
 # 'gs://...') and an Airflow connection id that provides access to the storage
@@ -466,6 +471,7 @@ dag_concurrency = 16
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 non_pooled_task_slot_count = 128
+conn_env_prefix = AIRFLOW_CONN_
 
 [cli]
 api_client = airflow.api.client.local_client

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -22,11 +22,15 @@ import logging
 import os
 import random
 
+from airflow import configuration
 from airflow import settings
 from airflow.models import Connection
 from airflow.exceptions import AirflowException
 
-CONN_ENV_PREFIX = 'AIRFLOW_CONN_'
+CONN_ENV_PREFIX = configuration.get(
+    section='core',
+    key='conn_env_prefix',
+)
 
 
 class BaseHook(object):


### PR DESCRIPTION
Some background on this. The Redshift/Postgres connection strings stored in confidant becomes an environment variable starts with `CREDENTIALS_` and cannot be picked up by Airflow since it only picks up env starts with `AIRFLOW_CONN`.

We need a way to pick up credentials from Confidant and assign it to a env var that start with `AIRFLOW_CONN`.

I talked to the dev-environment team and they say that they currently do not support jinjia templating in `env.sls` so we can't assign an environment var through 
```
AIRFLOW_CONN_REDSHIFT_LYFTHOUSE= {{ pillar.credentials.redshift_lyfthouse }}
```

The only way is to do `export AIRFLOW_CONN_REDSHIFT=${CREDENTIALS_REDSHIFT_LYFTHOUSE}` right before we start the airflow worker/scheduler/webserver and this variable will not be available in `service_venv`.

The other way is to make this prefix configurable and in lyft case we can make it `CREDENTIALS_AIRFLOW_CONN` so that Airflow can pick it up like what this PR do...

