### PR TITLE
[DATAHELP-2134] replace line break with empty space in cmd

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -54,6 +54,7 @@ app = Celery(
 
 @app.task
 def execute_command(command):
+    command = command.replace('\r', ' ').replace('\n', ' ')
     logging.info("Executing command in Celery " + command)
     try:
         output = subprocess.check_output(


### PR DESCRIPTION
Not sure why line break could be added to the middle of a command. Let's remove potential line breaks in any cmd picked up by workers.