### PR TITLE
Allow SQLAlchemy version up to v1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ def do_setup():
             'requests>=2.5.1, <3',
             'setproctitle>=1.1.8, <2',
             'sshtunnel>=0.1.4,<0.2',
-            'sqlalchemy>=1.1.15, <=1.2.0',
+            'sqlalchemy>=1.1.15, <=1.3.0',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
             'tqdm==4.23.4',


### PR DESCRIPTION
`piptools.compile` is failing for ETL after [1], because
`amundsendatabuilder` depends on `sqlalchemy>1.2` and airflow depends on
`sqlalchemy<=1.2`.

This change was already made upstream [2], so I think it should be OK.
The changelog looks pretty innocuous [3].

[1] https://github.com/lyft/amundsendatabuilder/commit/b480d0087a32a99c40714ffb3042ba3d529d5a77
[2] https://github.com/apache/airflow/pull/4227
[3] https://docs.sqlalchemy.org/en/13/changelog/migration_13.html