### PR TITLE
Updating the flask version to be higher for airflow 1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ def do_setup():
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',
-            'flask>=0.11, <0.12',
+            'flask>=1.0, <2.0',
             'flask-admin==1.4.1',
             'flask-cache>=0.13.1, <0.14',
             'flask-login==0.2.11',


### PR DESCRIPTION
Upgrading the flask version in 1.9 apache airflow version to resolve the flask version conflict issue in the lyft-data-validation:
https://deploy.lyft.net/job/pythonlyftdatavalidation-deploy-setup/56/console
https://github.com/lyft/python-lyft-data-validation