### PR TITLE
Relax tqdm dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ def do_setup():
             'sqlalchemy>=1.1.15, <=1.3.0',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
-            'tqdm==4.23.4',
+            'tqdm>=4.23.4',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ def do_setup():
             'sqlalchemy>=1.1.15, <=1.3.0',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
-            'tqdm>=4.23.4',
+            'tqdm>=4.23.4, <5',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={


### PR DESCRIPTION
Try to update some deps in etl and found this dependency is pinned and caused failure. I don't think we need to pin this dep and it is used in backfill progress bar.