### PR TITLE
Import env context dag and task vars from AIRFLOW-2463

### DIFF
--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -13,27 +13,49 @@
 # limitations under the License.
 #
 
+AIRFLOW_VAR_NAME_FORMAT_MAPPING = {
+    'AIRFLOW_CONTEXT_DAG_ID': {'default': 'airflow.ctx.dag_id',
+                               'env_var_format': 'AIRFLOW_CTX_DAG_ID'},
+    'AIRFLOW_CONTEXT_TASK_ID': {'default': 'airflow.ctx.task_id',
+                                'env_var_format': 'AIRFLOW_CTX_TASK_ID'},
+    'AIRFLOW_CONTEXT_EXECUTION_DATE': {'default': 'airflow.ctx.execution_date',
+                                       'env_var_format': 'AIRFLOW_CTX_EXECUTION_DATE'},
+    'AIRFLOW_CONTEXT_DAG_RUN_ID': {'default': 'airflow.ctx.dag_run_id',
+                                   'env_var_format': 'AIRFLOW_CTX_DAG_RUN_ID'}
+}
 
-def context_to_airflow_vars(context):
+
+def context_to_airflow_vars(context, in_env_var_format=False):
     """
     Given a context, this function provides a dictionary of values that can be used to
     externally reconstruct relations between dags, dag_runs, tasks and task_instances.
+    Default to abc.def.ghi format and can be made to ABC_DEF_GHI format if
+    in_env_var_format is set to True.
 
-    :param context: The context for the task_instance of interest
+    :param context: The context for the task_instance of interest.
     :type context: dict
+    :param in_env_var_format: If returned vars should be in ABC_DEF_GHI format.
+    :type in_env_var_format: bool
+    :return task_instance context as dict.
     """
     params = dict()
-    dag = context.get('dag')
-    if dag and dag.dag_id:
-        params['airflow.ctx.dag.dag_id'] = dag.dag_id
-    dag_run = context.get('dag_run')
-    if dag_run and dag_run.execution_date:
-        params['airflow.ctx.dag_run.execution_date'] = dag_run.execution_date.isoformat()
-    task = context.get('task')
-    if task and task.task_id:
-        params['airflow.ctx.task.task_id'] = task.task_id
+    if in_env_var_format:
+        name_format = 'env_var_format'
+    else:
+        name_format = 'default'
     task_instance = context.get('task_instance')
+    if task_instance and task_instance.dag_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_ID'][
+            name_format]] = task_instance.dag_id
+    if task_instance and task_instance.task_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_TASK_ID'][
+            name_format]] = task_instance.task_id
     if task_instance and task_instance.execution_date:
-        params['airflow.ctx.task_instance.execution_date'] = \
-            task_instance.execution_date.isoformat()
+        params[
+            AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_EXECUTION_DATE'][
+                name_format]] = task_instance.execution_date.isoformat()
+    dag_run = context.get('dag_run')
+    if dag_run and dag_run.run_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_RUN_ID'][
+            name_format]] = dag_run.run_id
     return params


### PR DESCRIPTION
1. Cherry pick changes to BashOperator and PythonOperator from:
https://github.com/lyft/incubator-airflow/commit/e9babff4eb3334b0d71cda31c2f6cbfe7b741389

2. Based on PR: [AIRFLOW-2463] Make task instance context available for hive queries
