### PR TITLE
Fix owner, email environment setting issue

### DIFF
--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -49,11 +49,19 @@ def context_to_airflow_vars(context, in_env_var_format=False):
         name_format = 'default'
     task = context.get('task')
     if task and task.email:
-        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_EMAIL'][
-            name_format]] = task.email
+        if isinstance(task.email, str):
+            params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_EMAIL'][
+                name_format]] = task.email
+        elif isinstance(task.email, list):
+            params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_EMAIL'][
+                name_format]] = ','.join(task.email)
     if task and task.owner:
-        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_OWNER'][
-            name_format]] = task.owner
+        if isinstance(task.owner, str):
+            params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_OWNER'][
+                name_format]] = task.owner
+        elif isinstance(task.owner, list):
+            params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_OWNER'][
+                name_format]] = ','.join(task.owner)
     task_instance = context.get('task_instance')
     if task_instance and task_instance.dag_id:
         params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_ID'][


### PR DESCRIPTION
DAG's owner, email field could be list etc. And for os env value, it can only be string type. Convert list to string if that's the case.

Test on tars