### PR TITLE
Do the same audit that etl repo did to fininfra airflow

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -23,6 +23,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
+from airflow.utils.operator_helpers import context_to_airflow_vars
 
 
 class BashOperator(BaseOperator):
@@ -67,6 +68,18 @@ class BashOperator(BaseOperator):
         which will be cleaned afterwards
         """
         bash_command = self.bash_command
+        self.log.info("Tmp dir root location: \n %s", gettempdir())
+
+        # Prepare env for child process.
+        if self.env is None:
+            self.env = os.environ.copy()
+        airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
+        self.log.info("Exporting the following env vars:\n" +
+                      '\n'.join(["{}={}".format(k, v)
+                                 for k, v in
+                                 airflow_context_vars.items()]))
+        self.env.update(airflow_context_vars)
+
         self.log.info("Tmp dir root location: \n %s", gettempdir())
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -14,31 +14,48 @@
 #
 
 
-def context_to_airflow_vars(context):
+AIRFLOW_VAR_NAME_FORMAT_MAPPING = {
+    'AIRFLOW_CONTEXT_DAG_ID': {'default': 'airflow.ctx.dag_id',
+                               'env_var_format': 'AIRFLOW_CTX_DAG_ID'},
+    'AIRFLOW_CONTEXT_TASK_ID': {'default': 'airflow.ctx.task_id',
+                                'env_var_format': 'AIRFLOW_CTX_TASK_ID'},
+    'AIRFLOW_CONTEXT_EXECUTION_DATE': {'default': 'airflow.ctx.execution_date',
+                                       'env_var_format': 'AIRFLOW_CTX_EXECUTION_DATE'},
+    'AIRFLOW_CONTEXT_DAG_RUN_ID': {'default': 'airflow.ctx.dag_run_id',
+                                   'env_var_format': 'AIRFLOW_CTX_DAG_RUN_ID'}
+}
+
+
+def context_to_airflow_vars(context, in_env_var_format=False):
     """
     Given a context, this function provides a dictionary of values that can be used to
     externally reconstruct relations between dags, dag_runs, tasks and task_instances.
-
-    :param context: The context for the task_instance of interest
+    Default to abc.def.ghi format and can be made to ABC_DEF_GHI format if
+    in_env_var_format is set to True.
+    :param context: The context for the task_instance of interest.
     :type context: dict
+    :param in_env_var_format: If returned vars should be in ABC_DEF_GHI format.
+    :type in_env_var_format: bool
+    :return task_instance context as dict.
     """
-    params = {}
-    dag = context.get('dag')
-    if dag and dag.dag_id:
-        params['airflow.ctx.dag.dag_id'] = dag.dag_id
-
-    dag_run = context.get('dag_run')
-    if dag_run and dag_run.execution_date:
-        params['airflow.ctx.dag_run.execution_date'] = dag_run.execution_date.isoformat()
-
-    task = context.get('task')
-    if task and task.task_id:
-        params['airflow.ctx.task.task_id'] = task.task_id
-
+    params = dict()
+    if in_env_var_format:
+        name_format = 'env_var_format'
+    else:
+        name_format = 'default'
     task_instance = context.get('task_instance')
+    if task_instance and task_instance.dag_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_ID'][
+            name_format]] = task_instance.dag_id
+    if task_instance and task_instance.task_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_TASK_ID'][
+            name_format]] = task_instance.task_id
     if task_instance and task_instance.execution_date:
-        params['airflow.ctx.task_instance.execution_date'] = (
-            task_instance.execution_date.isoformat()
-        )
-
+        params[
+            AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_EXECUTION_DATE'][
+                name_format]] = task_instance.execution_date.isoformat()
+    dag_run = context.get('dag_run')
+    if dag_run and dag_run.run_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_RUN_ID'][
+            name_format]] = dag_run.run_id
     return params


### PR DESCRIPTION
Per Jim, they are only using two operators: pythonOperator and financialETLOperator which is a subclass of bashOperator. 

So the following change should cover the fin-infra use case.