### PR TITLE
[DPTOOLS-2680] fix false alarm in UI

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -433,6 +433,22 @@ class SchedulerJob(BaseJob):
             (timezone.utcnow() - self.latest_heartbeat).seconds < scheduler_health_check_threshold
         )
 
+    def succeed_recently(self):
+        """
+        Did this SchedulerJob succeed recently?
+
+        We define the job succeeded recently if the job state is success
+        and ends within the threshold defined in the ``scheduler_health_check_threshold``
+        config setting.
+
+        :rtype: boolean
+        """
+        scheduler_health_check_threshold = conf.getint('scheduler', 'scheduler_health_check_threshold')
+        return (
+            self.state == State.SUCCESS and self.end_date and
+            (timezone.utcnow() - self.end_date).seconds < scheduler_health_check_threshold
+        )
+
     @provide_session
     def manage_slas(self, dag, session=None):
         """

--- a/airflow/www_rbac/templates/appbuilder/baselayout.html
+++ b/airflow/www_rbac/templates/appbuilder/baselayout.html
@@ -48,7 +48,7 @@
       <div class="row">
           {% block messages %}
             {% include 'appbuilder/flash.html' %}
-            {% if scheduler_job is defined and (not scheduler_job or not scheduler_job.is_alive()) %}
+            {% if scheduler_job is defined and (not scheduler_job or not (scheduler_job.is_alive() or scheduler_job.succeed_recently())) %}
               <div class="alert alert-warning">
                 <p>The scheduler does not appear to be running.
                 {% if scheduler_job %}

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -127,6 +127,14 @@ class SchedulerJobTest(unittest.TestCase):
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
         self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")
 
+    def test_succeed_recently(self):
+        job = SchedulerJob(None, heartrate=10, state=State.SUCCESS)
+        job.end_date = timezone.utcnow() - datetime.timedelta(seconds=10)
+        self.assertTrue(job.succeed_recently())
+
+        job.end_date = timezone.utcnow() - datetime.timedelta(seconds=31)
+        self.assertFalse(job.succeed_recently())
+
     def run_single_scheduler_loop_with_no_dags(self, dags_folder):
         """
         Utility function that runs a single scheduler loop without actually


### PR DESCRIPTION
This PR is aiming to solve the false alarm below:
![image](https://user-images.githubusercontent.com/26216756/75277743-6f8a6e00-57bd-11ea-9dcf-36837cdf607a.png)

We restart scheduler after 10 runs https://github.com/lyft/airflowinfra/blob/7ad87df746ea462e6e752e0bc1895c6c15023f65/ops/config/pillar/airflowinfrascheduler.sls#L4, which means there is a short period (~ 5 seconds, check the db query below) with no scheduler job alive. In our situation, we should not consider the scheduler to be done for the period.

```
airflowinfra=> select * from job where job_type = 'SchedulerJob' order by latest_heartbeat desc limit 2;
   id    | dag_id |  state  |   job_type   |          start_date           |           end_date            |       latest_heartbeat        | executor_class |  hostname   | unixname 
---------+--------+---------+--------------+-------------------------------+-------------------------------+-------------------------------+----------------+-------------+----------
 1868021 |        | success | SchedulerJob | 2020-02-25 08:11:49.883763+00 | 2020-02-25 08:13:29.082672+00 | 2020-02-25 08:13:26.09628+00  | NoneType       | 10.46.49.80 | root
 1868015 |        | success | SchedulerJob | 2020-02-25 08:10:04.751189+00 | 2020-02-25 08:11:44.164813+00 | 2020-02-25 08:11:41.052322+00 | NoneType       | 10.46.49.80 | root

airflowinfra=> select * from job where job_type = 'SchedulerJob' order by latest_heartbeat desc limit 2;
   id    | dag_id |  state  |   job_type   |          start_date           |           end_date            |       latest_heartbeat        | executor_class |  hostname   | unixname 
---------+--------+---------+--------------+-------------------------------+-------------------------------+-------------------------------+----------------+-------------+----------
 1868024 |        | running | SchedulerJob | 2020-02-25 08:13:34.822287+00 |                               | 2020-02-25 08:13:59.015748+00 | NoneType       | 10.46.49.80 | root
 1868021 |        | success | SchedulerJob | 2020-02-25 08:11:49.883763+00 | 2020-02-25 08:13:29.082672+00 | 2020-02-25 08:13:26.09628+00  | NoneType       | 10.46.49.80 | root
```