### PR TITLE
Add custom LyftCeleryExecutor

### DIFF
--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -19,6 +19,7 @@ from airflow import configuration
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
+from airflow.executors.lyft_celery_executor import LyftCeleryExecutor
 
 try:
     from airflow.executors.celery_executor import CeleryExecutor
@@ -41,6 +42,8 @@ if _EXECUTOR == 'LocalExecutor':
     DEFAULT_EXECUTOR = LocalExecutor()
 elif _EXECUTOR == 'CeleryExecutor':
     DEFAULT_EXECUTOR = CeleryExecutor()
+elif _EXECUTOR == 'LyftCeleryExecutor':
+    DEFAULT_EXECUTOR = LyftCeleryExecutor()
 elif _EXECUTOR == 'SequentialExecutor':
     DEFAULT_EXECUTOR = SequentialExecutor()
 elif _EXECUTOR == 'MesosExecutor':

--- a/airflow/executors/lyft_celery_executor.py
+++ b/airflow/executors/lyft_celery_executor.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from airflow.exceptions import AirflowException
+from airflow.executors.celery_executor import (
+    app,
+    celery_states,
+    CeleryExecutor,
+    DEFAULT_QUEUE,
+)
+from typing import Dict
+
+import json
+import logging
+import subprocess
+import os
+
+CONFIDANT_JSON_FILE = '/dev/shm/confidant/confidant_data'
+
+def refresh_env_from_confidant():
+    # type: () -> Dict[str, str]
+    env = os.environ.copy()
+    with open(CONFIDANT_JSON_FILE, 'r') as f:
+        confidant_creds = json.load(f)['credentials']
+        for (key, value) in confidant_creds.items():
+            env['CREDENTIALS_{}'.format(key.upper())] = value
+
+    return env
+
+@app.task
+def execute_command_with_fresh_creds(command):
+    """
+    See execute_command() from celery_executor.py
+    """
+    logging.info("Executing command in Celery " + command)
+    try:
+        output = subprocess.check_output(
+            command,
+            shell=True,
+            env=refresh_env_from_confidant(),
+            close_fds=True,
+            stderr=subprocess.STDOUT,
+        )
+        logging.info(output)
+    except subprocess.CalledProcessError as e:
+        logging.exception('execute_command encountered a CalledProcessError')
+        logging.error(e.output)
+        raise AirflowException('Celery command failed')
+
+
+class LyftCeleryExecutor(CeleryExecutor):
+    """
+    Exactly like the CeleryExecutor, except that it refreshes
+    environment variables with the latest Confidant credentials before
+    launching the subprocess corresponding to each task.
+    """
+
+    def execute_async(self, key, command, queue=DEFAULT_QUEUE):
+        self.logger.info("[celery] queuing {key} through celery, "
+                         "queue={queue}".format(**locals()))
+        self.tasks[key] = execute_command_with_fresh_creds.apply_async(
+            args=[command], queue=queue)
+        self.last_state[key] = celery_states.PENDING

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -75,7 +75,7 @@ sphinx
 sphinx-argparse
 Sphinx-PyPI-upload
 sphinx_rtd_theme
-sqlalchemy
+sqlalchemy==1.3.0
 statsd
 thrift
 thrift_sasl

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -43,6 +43,7 @@ ipython
 jaydebeapi
 jinja2<2.9.0
 jira
+JPype1==0.7.1  # Dropped python2 support
 ldap3
 lxml
 markdown

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-alembic
+alembic<0.9,>=0.8.3
 bcrypt
 boto
 celery
@@ -22,31 +22,31 @@ coverage
 coveralls
 croniter
 cryptography
-dill
+dill<0.3,>=0.2.2
 docker-py
 filechunkio
 flake8
-flask
-flask-admin
+flask<1.1.0
+flask-admin<=1.5.0,>=1.4.1
 flask-bcrypt
 flask-cache
 flask-login==0.2.11
-Flask-WTF
+Flask-WTF==0.14.0
 flower
 freezegun
-future
+future<0.16,>=0.15.0
 gunicorn
 hdfs
 hive-thrift-py
 impyla
 ipython
 jaydebeapi
-jinja2<2.9.0
+jinja2>=2.10,<3.0
 jira
 JPype1==0.7.1  # Dropped python2 support
 ldap3
-lxml
-markdown
+lxml>=3.6.0,<4.0
+markdown==2.5.2
 mock
 mysqlclient
 nose
@@ -63,11 +63,11 @@ pyhive
 pykerberos
 PyOpenSSL
 PySmbClient
-python-daemon
-python-dateutil
+python-daemon>=2.1.1, <2.2
+python-dateutil>=2.3, <3
 qds-sdk>=1.9.6
 redis
-requests
+requests>=2.5.1, <3
 requests-kerberos
 setproctitle
 slackclient
@@ -80,3 +80,4 @@ statsd
 thrift
 thrift_sasl
 unicodecsv
+werkzeug==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,8 @@ google_authentication = ['Flask-OAuthlib>=0.9.1', 'PyJWT>=1.5.3']
 qds = ['qds-sdk>=1.9.6']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 
-all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
+# all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
+all_dbs = postgres + mysql + hive
 devel = [
     'click',
     'freezegun',
@@ -211,10 +212,10 @@ def do_setup():
             'flask-wtf==0.14',
             'funcsigs>=1.0.0, <=1.0.2',
             'future>=0.15.0, <0.16',
-            'gitpython>=2.0.2',
+            'gitpython>=2.0.2,<3',
             # 'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.10, <3.0',
-            'JPype1<0.6.0',  # Dropped python2 support
+            'JPype1==0.7.1',  # Dropped python2 support
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'numpy>=0.17.1, <=1.16.0',  # Dropped python2 support
@@ -234,6 +235,7 @@ def do_setup():
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
             'tqdm>=4.23.4, <5',
+            'werkzeug<=0.15',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -214,10 +214,12 @@ def do_setup():
             'gitpython>=2.0.2',
             # 'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.10, <3.0',
+            'JPype1==0.6.3',  # Dropped python2 support
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
+            'numpy>=0.17.1, <=1.16.0',  # Dropped python2 support
             'paramiko>=2.1',
-            'pandas>=0.17.1, <1.0.0',
+            'pandas>=0.17.1, <=0.23.1',  # Dropped python2 support
             'pendulum==1.4.4',
             'psutil>=4.2.0, <5.0.0',
             'pygments>=2.0.1, <3.0',

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ def do_setup():
             'gitpython>=2.0.2',
             # 'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.10, <3.0',
-            'JPype1==0.6.3',  # Dropped python2 support
+            'JPype1<0.6.0',  # Dropped python2 support
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'numpy>=0.17.1, <=1.16.0',  # Dropped python2 support

--- a/setup.py
+++ b/setup.py
@@ -169,8 +169,7 @@ google_authentication = ['Flask-OAuthlib>=0.9.1', 'PyJWT>=1.5.3']
 qds = ['qds-sdk>=1.9.6']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 
-# all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
-all_dbs = postgres + mysql + hive
+all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
 devel = [
     'click',
     'freezegun',
@@ -212,15 +211,13 @@ def do_setup():
             'flask-wtf==0.14',
             'funcsigs>=1.0.0, <=1.0.2',
             'future>=0.15.0, <0.16',
-            'gitpython>=2.0.2,<3',
+            'gitpython>=2.0.2',
             # 'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.10, <3.0',
-            'JPype1==0.7.1',  # Dropped python2 support
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
-            'numpy>=0.17.1, <=1.16.0',  # Dropped python2 support
             'paramiko>=2.1',
-            'pandas>=0.17.1, <=0.23.1',  # Dropped python2 support
+            'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',
             'psutil>=4.2.0, <5.0.0',
             'pygments>=2.0.1, <3.0',
@@ -235,7 +232,6 @@ def do_setup():
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
             'tqdm>=4.23.4, <5',
-            'werkzeug<=0.15',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={


### PR DESCRIPTION
This executor refreshes the `CREDENTIALS_*` environment variables with
the latest values from Confidant before launching each task. This means
we won't have to restart the workers every time someone updates
Confidant.

I tested in onebox by creating a dummy task that just prints the output
of a Confidant variable, editing the variable, and re-running (without
restarting the worker).

Note that this change won't take effect until we update the value of
`core.executor` in `airflow.cfg`. I plan to do that in 2 follow-up PRs:
1 to change the executor in staging, then a follow-up to change it in
prod (once we've had a few hours to monitor).

Though this change is relatively small, I went down several dead-ends
before settling on this approach. A few things I tried:

## Create an executor plugin in python-lyft-etl

This would have been nice because we could use it for both airflowinfra
and for the etl cluster. But the structures of the airflow.executors
module, the implementation of CeleryExecutor, and the implementation of
the plugins manager have all changed so much between our two Airflow
versions that there was no clean way do do this.

Also, it was really difficult to debug when the executor wasn't able to
load correctly because the plugins manager gives an opaque backtrace. I
think it had something to do with cyclic imports in Airflow 1.8, but I
eventually gave up because I realized it would be a maintenance
nightmare.

## Override heartbeat() instead of @app.task and execute_async()

It'd be nice if we could just periodically update the process'
environment variables inside Executor.hearbeat(). But that doesn't work,
because the Celery workers have already been launched and are running in
independent processes, and updating the airflow worker's environment
variables has no effect on them.