### PR TITLE
[DATAHELP-2950] Log more on deepcopy failure

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2351,7 +2351,12 @@ class BaseOperator(object):
 
         for k, v in list(self.__dict__.items()):
             if k not in shallow_copy:
-                setattr(result, k, copy.deepcopy(v, memo))
+                try:
+                    setattr(result, k, copy.deepcopy(v, memo))
+                except Exception as e:
+                    logging.exception('Failed deepcopy on member variable '
+                                      'key: {k} ,value: {v}'.format(k=k, v=v))
+                    raise e
             else:
                 setattr(result, k, copy.copy(v))
         return result


### PR DESCRIPTION
When user clears task's state from UI, Airflow performs deepcopy of the Dag instance then clear the state. Sometimes Airflow fails on deepcopy for customer's DAG is not deepcopiable, however this [ticket's](https://jira.lyft.net/browse/DATAHELP-2950) case was not reproducible. Thus, adding more logs to see why it's happening if it happens again.
