### PR TITLE
[DPTOOLS-2719] Fix resources equal function

### DIFF
--- a/airflow/utils/operator_resources.py
+++ b/airflow/utils/operator_resources.py
@@ -116,7 +116,7 @@ class Resources(object):
         self.gpus = GpuResource(gpus)
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return type(self) == type(other) and self.__dict__ == other.__dict__
 
     def __repr__(self):
         return str(self.__dict__)


### PR DESCRIPTION
See this error when loading https://airflow-staging.lyft.net/graph?dag_id=dp_tools_showcase
<img width="1139" alt="Screen Shot 2020-03-12 at 11 15 45 PM" src="https://user-images.githubusercontent.com/26216756/76645150-9bc02180-6515-11ea-8258-4918862f2af3.png">

Found out the error in per dag scheduler:
```
[2020-03-13 07:52:14,656] {logging_mixin.py:112} INFO - [2020-03-13 07:52:14,656] {serialized_objects.py:211} WARNING - Failed to stringify.
Traceback (most recent call last):
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 182, in _serialize
    return SerializedBaseOperator.serialize_operator(var)
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 325, in serialize_operator
    serialize_op = cls.serialize_to_json(op, cls._decorated_fields)
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 138, in serialize_to_json
    if cls._is_excluded(value, key, object_to_serialize):
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 397, in _is_excluded
    return super(SerializedBaseOperator, cls)._is_excluded(var, attrname, op)
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 127, in _is_excluded
    cls._value_is_hardcoded_default(attrname, var)
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/serialization/serialized_objects.py", line 276, in _value_is_hardcoded_default
    (cls._CONSTRUCTOR_PARAMS[attrname].default is value or (value in [{}, []])):
  File "/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/utils/operator_resources.py", line 119, in __eq__
    return self.__dict__ == other.__dict__
AttributeError: 'dict' object has no attribute '__dict__'
```

The exception comes out because we pass dictionary to resources and the dictionary does not have __dict__ attribute. https://github.com/lyft/dataplatformairflow/blob/65ef43626af21b9d1f4592dc4779956362580ab0/data/dataplatformairflow/dags/dp_tools_showcase_dag.py#L69

Tested this SHA in devbox and verified that the DAG can be loaded