### PR TITLE
[DPTOOLS-2717]Adding default role. Sync dag for default role. Check permission for default role

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -214,6 +214,8 @@ class Airflow(AirflowBaseView):
     @has_access
     @provide_session
     def index(self, session=None):
+        appbuilder.sm.sync_dag_for_default_role()
+
         DM = models.DagModel
 
         hide_paused_dags_by_default = conf.getboolean('webserver',


### PR DESCRIPTION
Issue link: https://jira.lyft.net/browse/DPTOOLS-2717
### Description:
Our final target is to have new airflow enable auto registration for new users. This PR is to create a "Default" role and sync and check the dag for this role. 
The "Default" role have these properties:
1. Default role can see all the menus exclude "Security" menu and have all permissions. We may have improvement after we finish this whole task.
2. Default role can load public dag. Public dag here means the dag without "access_control" parameter. Here is the example with "access_control" parameter: https://github.com/lyft/corpdataetl/blob/master/data/corpdataetl/dags/dag_anaplan_cost_center_heir.py#L57. Here is the one without:https://github.com/lyft/dataplatformairflow/blob/master/data/dataplatformairflow/dags/dp_tools_showcase_dag.py#L41

### How to
I created and grant the view permission for default role in security.py. Then I create two methods to check and sync the public dag for default role. 
I found in views.py, there have two main functions/scenarios need to check the default role:
1. When default role customer loads the page, /home, the public dags should display. So I create a method: sync_dag_for_default_role to sync public dag for default role no matter for new user or exist user.
2. Customer can go to directly the view, /code, which need "has_dag_access" check. So I create a method: check_default_role_access to check if default role has this dag access.

### Test
I changed the log in role to "Default" role from "Admin" role: https://github.com/lyft/airflowinfra/blob/master/ops/config/states/webserver_config.py.template#L61. 
Then I sign in to the page. 
<img width="1680" alt="Screen Shot 2020-03-16 at 10 34 05 AM" src="https://user-images.githubusercontent.com/7109700/76784971-d45c3700-6771-11ea-9a7a-f881312540ea.png">
Remember here, since I didn't change the register button, so now only can click "sign in" button to log in as "Default" role.
Here is the home page: 
<img width="1671" alt="Screen Shot 2020-03-16 at 10 36 02 AM" src="https://user-images.githubusercontent.com/7109700/76785060-f950aa00-6771-11ea-9a42-48ec65f886dd.png">
As a default role, I only can see two dags. I also can trigger the dag and check the code of dag:
<img width="1680" alt="Screen Shot 2020-03-16 at 10 37 19 AM" src="https://user-images.githubusercontent.com/7109700/76785164-28ffb200-6772-11ea-8e7d-88c16e45ad88.png">

### Unit test
Since this is not the same approach we discussed before, and I assume this may have lots of response. So I prefer not adding unit test before we all agree with the function part. After that, I will add unit tests either in this PR or in a separate PR.





Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
