### PR TITLE
Remove register button from login page

### DIFF
--- a/airflow/www_rbac/templates/appbuilder/general/security/login_oauth.html
+++ b/airflow/www_rbac/templates/appbuilder/general/security/login_oauth.html
@@ -1,0 +1,65 @@
+<!-- extend base layout -->
+{% extends "appbuilder/base.html" %}
+
+{% block content %}
+
+<script type="text/javascript">
+
+var baseLoginUrl = "{{url_for('AuthOAuthView.login')}}";
+var baseRegisterUrl = "{{url_for('AuthOAuthView.login')}}";
+var next = "?next={{request.args.get('next', '')}}"
+
+var currentSelection = "";
+
+function set_openid(url, pr)
+{
+    $('.provider-select').removeClass('fa-black');
+    $('#' + pr).addClass('fa-black');
+    currentSelection = pr;
+}
+
+
+function signin() {
+    if (currentSelection != "") {
+        window.location.href = baseLoginUrl + currentSelection + next;
+    }
+}
+
+function register() {
+    if (currentSelection != "") {
+        window.location.href = baseRegisterUrl + currentSelection + '/register' + next;
+    }
+}
+
+
+</script>
+
+<div class="container">
+        <div id="loginbox" style="margin-top:50px;" class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">
+            <div class="panel panel-primary" >
+                <div class="panel-heading">
+                    <div class="panel-title">{{ title }}</div>
+                </div>
+                <div style="padding-top:30px" class="panel-body" >
+
+                    <div class="help-block">{{_("Please choose one of the following providers:")}}</div>
+                    <div class="center-block btn-group btn-group-lg" role="group">
+                        <center>
+                        {% for pr in providers %}
+                            <a class="btn btn-primary" href="javascript:set_openid('{{url_for('AuthOAuthView.login', provider=pr.name)}}', '{{pr.name}}');">
+                                <i id="{{pr.name}}" class="provider-select fa {{pr.icon}} fa-3x"></i>
+                            </a>
+                        {% endfor %}
+                        </center>
+                     </div>
+                     <div>
+                         <br></br>
+                        <a onclick="signin();" class="btn btn-primary btn-block" type="submit">{{_('Sign In')}}</a>
+                     </div>
+                </div>
+            </div>
+        </div>
+</div>
+
+
+{% endblock %}


### PR DESCRIPTION
Have tested this in Devbox and it works like a charm. After I removed this button, the `Airflow redirected you too many times` error is gone too because I could not reproduce it after this change. I seems like that the "Register" button is actually useless and even has a negative impact on UI.

How I tested in devbox:
1. Override Flask Appbuilder's built-in login template
```
root@airflowinfra-legacy:/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/www_rbac/templates/appbuilder# mkdir -p general/security
root@airflowinfra-legacy:/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/www_rbac/templates/appbuilder# cd general/security
root@airflowinfra-legacy:/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/www_rbac/templates/appbuilder/general/security# vim login_oauth.html
root@airflowinfra-legacy:/srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/www_rbac/templates/appbuilder/general/security# ls -a
.  ..  login_oauth.html
```
The added `login_oauth.html` file is the exactly the one in this PR.

2. Restarted webserver after the change:
```
root@airflowinfra-legacy:/etc/service# sudo sv force-restart airflowinfra-web 
ok: run: airflowinfra-web: (pid 16720) 0s
```

3. Then the UI is changed to:
<img width="1518" alt="Screen Shot 2020-03-21 at 10 34 23 PM" src="https://user-images.githubusercontent.com/26216756/77243386-c457b380-6bc6-11ea-8ef9-16acac89222e.png">

I deleted myself from the `ab_user` table, cleared my browser data, opened a new Incognito window, the login works perfectly for me as a new customer.


This is the `Airflow redirected you too many times` error that won't exist anymore.

![image](https://user-images.githubusercontent.com/26216756/77243435-29130e00-6bc7-11ea-9aa9-1f74ac4ae5b3.png)
