### PR TITLE
[DPTOOLS-2721] Fix error in refreshing dags on UI

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -483,7 +483,7 @@ class SerializedDAG(DAG, BaseSerialization):
     not pickle-able. SerializedDAG works for all DAGs.
     """
 
-    _decorated_fields = {'schedule_interval', 'default_args'}
+    _decorated_fields = {'schedule_interval', 'default_args', '_access_control'}
 
     @staticmethod
     def __get_constructor_defaults():  # pylint: disable=no-method-argument


### PR DESCRIPTION
Before this change, the access control is serialized in DB like this:
```
"_access_control": {"DPToolsMember": {"__var": ["can_dag_read", "can_dag_edit"], "__type": "set"}}
```
which errors out during deserialization.

After the change, it is like this:
```
"_access_control": {'__var': {'DPToolsMember': {'__var': ['can_dag_edit', 'can_dag_read'], '__type': 'set'}}, '__type': 'dict'}
```
which works well.

A screenshot to verify it works in devbox:
<img width="1517" alt="Screen Shot 2020-03-26 at 1 27 07 AM" src="https://user-images.githubusercontent.com/26216756/77625517-f3d92980-6f00-11ea-9219-eb54a36d97cd.png">
