### PR TITLE
[AIRFLOW-4537] Remove the mkdir_p function in favour of native Python pathlib (#5301)

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -25,9 +25,9 @@ from __future__ import unicode_literals
 from builtins import str
 from collections import OrderedDict
 import copy
-import errno
 from future import standard_library
 import os
+import pathlib
 import shlex
 import six
 from six import iteritems
@@ -518,17 +518,6 @@ class AirflowConfigParser(ConfigParser):
         )
 
 
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise AirflowConfigException(
-                'Error creating {}: {}'.format(path, exc.strerror))
-
-
 def get_airflow_home():
     return expand_env_var(os.environ.get('AIRFLOW_HOME', '~/airflow'))
 
@@ -544,7 +533,7 @@ def get_airflow_config(airflow_home):
 
 AIRFLOW_HOME = get_airflow_home()
 AIRFLOW_CONFIG = get_airflow_config(AIRFLOW_HOME)
-mkdir_p(AIRFLOW_HOME)
+pathlib.Path(AIRFLOW_HOME).mkdir(parents=True, exist_ok=True)
 
 
 # Set up dags folder for unit tests

--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -31,7 +31,7 @@ from qds_sdk.commands import Command, HiveCommand, PrestoCommand, HadoopCommand,
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.configuration import conf, mkdir_p
+from airflow.configuration import conf
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 

--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -19,6 +19,7 @@
 #
 """Qubole hook"""
 import os
+import pathlib
 import time
 import datetime
 import six
@@ -184,7 +185,7 @@ class QuboleHook(BaseHook):
                 conf.get('core', 'BASE_LOG_FOLDER')
             )
             resultpath = logpath + '/' + self.dag_id + '/' + self.task_id + '/results'
-            mkdir_p(resultpath)
+            pathlib.Path(resultpath).mkdir(parents=True, exist_ok=True)
             fp = open(resultpath + '/' + iso, 'wb')
 
         if self.cmd is None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -17,13 +17,15 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import pathlib
 import six
 import sys
 import tempfile
 
-from airflow.configuration import conf, mkdir_p
-from tests.compat import patch
+
 from tests.test_utils.config import conf_vars
+from airflow import configuration as conf
+from tests.compat import patch
 
 
 if six.PY2:
@@ -122,7 +124,7 @@ class settings_context(object):
 
             # Create the directory structure
             dir_path = os.path.join(self.settings_root, dir)
-            mkdir_p(dir_path)
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
             # Add the __init__ for the directories
             # This is required for Python 2.7

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -19,6 +19,7 @@
 
 from datetime import (datetime, timedelta)
 import os
+import pathlib
 import sys
 import tempfile
 import unittest
@@ -26,8 +27,9 @@ import mock
 
 from mock import MagicMock, PropertyMock
 
-from airflow.configuration import conf, mkdir_p
-from airflow.jobs import DagFileProcessor, LocalTaskJob as LJ
+from airflow import configuration as conf
+from airflow.jobs import DagFileProcessor
+from airflow.jobs import LocalTaskJob as LJ
 from airflow.models import DagBag, TaskInstance as TI
 from airflow.utils import timezone
 from airflow.utils.dag_processing import (
@@ -101,7 +103,7 @@ class settings_context(object):
 
             # Create the directory structure
             dir_path = os.path.join(self.settings_root, dir)
-            mkdir_p(dir_path)
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
             # Add the __init__ for the directories
             # This is required for Python 2.7


### PR DESCRIPTION
Cherry-Pick commit. This commit can be ignored when we upgrade airflow versions

This fix is because mkdir_p has issues that pathlib fixes, and this should help fix tars web. 

---
Issue link: WILL BE INSERTED BY [boring-cyborg](https://github.com/kaxil/boring-cyborg)

Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
