### PR TITLE
[DPTOOLS-2800] Allow preload import

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -366,7 +366,15 @@ def import_local_settings():
         log.debug("Failed to import airflow_local_settings.", exc_info=True)
 
 
-def initialize():
+def preload_custom_imports():
+    """
+    Any custom imports that need to loaded and cached,
+    for example of custom hooks, sensors and operators
+    :rtype: None
+    """
+
+
+def initialize(preload_imports=False):
     configure_vars()
     prepare_syspath()
     import_local_settings()
@@ -377,6 +385,8 @@ def initialize():
     configure_orm()
     configure_action_logging()
 
+    if preload_imports:
+        preload_custom_imports()
     # Ensure we close DB connections at scheduler and gunicon worker terminations
     atexit.register(dispose_orm)
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -369,9 +369,12 @@ def import_local_settings():
 def preload_custom_imports():
     """
     Any custom imports that need to loaded and cached,
-    for example of custom hooks, sensors and operators
+    for example of custom hooks, sensors and operators.
+
+    This method is meant to be overridden in airflow_local_settings.py
     :rtype: None
     """
+    pass
 
 
 def initialize(preload_imports=False):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -611,7 +611,7 @@ class DagFileProcessorAgent(LoggingMixin):
         # in logging_config.py
         reload_module(import_module(airflow.settings.LOGGING_CLASS_PATH.rsplit('.', 1)[0]))
         reload_module(airflow.settings)
-        airflow.settings.initialize()
+        airflow.settings.initialize(preload_imports=True)
         del os.environ['CONFIG_PROCESSOR_MANAGER_LOGGER']
         processor_manager = DagFileProcessorManager(dag_directory,
                                                     file_paths,


### PR DESCRIPTION
With the change, we can create `airflow_local_settings.py` in airflowinfra and define `preload_custom_imports()` method in it. We just have to add all custom operators into the method.

The circular import error will be gone as well, because we only preload imports in dag processing, but not airflow init https://github.com/lyft/incubator-airflow/blob/08126ea3c7f108796d0500469d849fe5cde1b5e5/airflow/__init__.py#L47