### PR TITLE
hack: centralized dag to queue routing

### DIFF
--- a/airflow/executors/lyft_celery_executor.py
+++ b/airflow/executors/lyft_celery_executor.py
@@ -28,8 +28,6 @@ import logging
 import subprocess
 import os
 
-from airflow.models import Variable
-
 CONFIDANT_JSON_FILE = '/dev/shm/confidant/confidant_data'
 
 def refresh_env_from_confidant():

--- a/airflow/executors/lyft_celery_executor.py
+++ b/airflow/executors/lyft_celery_executor.py
@@ -86,7 +86,7 @@ class LyftCeleryExecutor(CeleryExecutor):
             if dag_id in self.py3_dag_id_whitelist:
                 queue = 'py3'
         except Exception as e:
-            self.logger.error('Failing to do queue routing because of {e}'.format(e=str(e)))
+            self.logger.error('Failed to do queue routing because of {e}'.format(e=str(e)))
 
         self.tasks[key] = execute_command_with_fresh_creds.apply_async(
             args=[command], queue=queue)

--- a/airflow/executors/lyft_celery_executor.py
+++ b/airflow/executors/lyft_celery_executor.py
@@ -70,6 +70,8 @@ class LyftCeleryExecutor(CeleryExecutor):
 
     def __init__(self):
         super(LyftCeleryExecutor, self).__init__()
+
+        # DAG IDs in this whitelist will be routed to the py3 queue
         self.py3_dag_id_whitelist = {
             'engdocs_page_views'
         }


### PR DESCRIPTION
Adding a hack to do centralized DAG-to-queue routing in Airflow scheduler that routes DAGs in the whitelist to `py3` queue which is consumed by the `sharedairflowworkerpy3` which runs on Python 3.6. 

Keeping the DAG-to-queue mapping centralized during py3 migration much easier since we don't need to update the `queue` field in 1000+ DAGs.