### PR TITLE
Support task instance policy

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -15,7 +15,7 @@
 from builtins import range
 
 from airflow import configuration
-from airflow.settings import Stats
+from airflow.settings import Stats, task_instance_policy
 from airflow.utils.state import State
 from airflow.utils.logging import LoggingMixin
 
@@ -75,7 +75,7 @@ class BaseExecutor(LoggingMixin):
             task_instance,
             command,
             priority=task_instance.task.priority_weight_total,
-            queue=task_instance.task.queue)
+            queue=task_instance.queue)
 
     def has_task(self, task_instance):
         """

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -48,7 +48,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.settings import Stats
 from airflow.task_runner import get_task_runner
-from airflow.settings import Stats, PROGRESS_BAR_FORMAT, task_instance_policy
+from airflow.settings import Stats, PROGRESS_BAR_FORMAT
 from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils.state import State
 from airflow.utils.db import provide_session, pessimistic_connection_handling
@@ -1003,11 +1003,6 @@ class SchedulerJob(BaseJob):
             .filter(TI.state.in_(states))
             .all()
         )
-
-        for task_instance in task_instances_to_examine:
-            task_instance_policy(task_instance)
-            session.merge(task_instance)
-        session.commit()
 
         # Put one task instance on each line
         if len(task_instances_to_examine) == 0:

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -45,10 +45,10 @@ from tqdm import tqdm
 from airflow import executors, models, settings
 from airflow import configuration as conf
 from airflow.exceptions import AirflowException
-from airflow.models import DAG, DagRun
+from airflow.models import DAG, DagRun, TaskInstance
 from airflow.settings import Stats
 from airflow.task_runner import get_task_runner
-from airflow.settings import Stats, PROGRESS_BAR_FORMAT
+from airflow.settings import Stats, PROGRESS_BAR_FORMAT, task_instance_policy
 from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils.state import State
 from airflow.utils.db import provide_session, pessimistic_connection_handling
@@ -1003,6 +1003,11 @@ class SchedulerJob(BaseJob):
             .filter(TI.state.in_(states))
             .all()
         )
+
+        for task_instance in task_instances_to_examine:
+            task_instance_policy(task_instance)
+            session.merge(task_instance)
+        session.commit()
 
         # Put one task instance on each line
         if len(task_instances_to_examine) == 0:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4492,6 +4492,7 @@ class DagRun(Base):
         # check for removed or restored tasks
         task_ids = []
         for ti in tis_in_db:
+            settings.task_instance_policy(ti)
             task_ids.append(ti.task_id)
             task_from_dag = None
             try:
@@ -4518,6 +4519,7 @@ class DagRun(Base):
 
             if task.task_id not in task_ids:
                 ti = TaskInstance(task, self.execution_date)
+                settings.task_instance_policy(ti)
                 session.add(ti)
 
         session.commit()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -365,7 +365,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         dag.resolve_template_files()
         dag.last_loaded = datetime.now()
 
-        for task in dag.tasks:
+        for task in dag.tasks:  # type: BaseOperator
             settings.policy(task)
 
         for subdag in dag.subdags:
@@ -1870,7 +1870,7 @@ class SkipMixin(object):
                 processed_tis_repr.add(repr(downstream_task))
         for downstream_task in all_downstream:
             all_downstream.extend(self.find_all_downstream_skippable(downstream_task, processed_tis_repr))
-            
+
         return all_downstream
 
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -98,19 +98,27 @@ engine = None
 Session = None
 
 
-def policy(task_instance):
+def task_instance_policy(task_instance):
+    # type: (TaskInstance) -> None
     """
-    This policy setting allows altering task instances right before they
-    are executed. It allows administrator to rewire some task parameters.
+    This policy setting allows altering task instance right before they
+    are queued by the scheduler.
 
-    Note that the ``TaskInstance`` object has an attribute ``task`` pointing
-    to its related task object, that in turns has a reference to the DAG
-    object. So you can use the attributes of all of these to define your
-    policy.
+    Note: this policy is not applied if the task is executed via
+    airflow {backfill,test}
+    """
+    pass
+
+
+def policy(operator):
+    # type: (BaseOperator) -> None
+    """
+    This policy setting allows altering operator during DagBag loading.
+    It allows administrator to rewire some operator parameters.
 
     To define policy, add a ``airflow_local_settings`` module
     to your PYTHONPATH that defines this ``policy`` function. It receives
-    a ``TaskInstance`` object and can alter it where needed.
+    a ``BaseOperator`` object and can alter it where needed.
 
     Here are a few examples of how this can be useful:
 


### PR DESCRIPTION
`policy` only modifies the operator (not task instance) during DagBag loading and a task can be executed multiple times in between. To achieve routing a task to different queue during retries, we need a way to mutate the task instances before each execution. Therefore, adding a new `task_instance_policy` that is applied to the task instance right before it is queued by the airflow scheduler.

Did some testing with the following setup:
airflow_local_settings.py:
```
def task_instance_policy(task_instance):
    if task_instance.try_number == 0:
        task_instance.queue = 'py3'
```

DAG:
```
from __future__ import print_function
from builtins import range
import airflow
from airflow.operators.python_operator import PythonOperator
from airflow.models import DAG

import time
from pprint import pprint
from datetime import timedelta

args = {
    'owner': 'airflow',
    'start_date': airflow.utils.dates.days_ago(2),
    'retries': 1,
    'retry_delay': timedelta(seconds=1),
}

dag = DAG(
    dag_id='test_route_switch', default_args=args,
    schedule_interval=timedelta(minutes=1))


def print_context(ds, **kwargs):
    print('hello world')
    raise Exception('oops')
```
and confirming that the task got routed to different queues during retries
```
[2020-05-07 17:08:42,340] {jobs.py:1131} INFO - Sending to executor (u'test_route_switch', u'print_the_context', datetime.datetime(2020, 5, 5, 0, 0)) with priority 1 and queue py3
...
[2020-05-07 17:08:50,780] {jobs.py:1131} INFO - Sending to executor (u'test_route_switch', u'print_the_context', datetime.datetime(2020, 5, 5, 0, 0)) with priority 1 and queue default
```
