### PR TITLE
Refresh more task_instance attributes

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1020,6 +1020,9 @@ class TaskInstance(Base, LoggingMixin):
             self.try_number = ti.try_number
             self.hostname = ti.hostname
             self.pid = ti.pid
+            self.queue = ti.queue
+            self.pool = ti.pool
+            self.priority_weight = ti.priority_weight
         else:
             self.state = None
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1023,6 +1023,11 @@ class TaskInstance(Base, LoggingMixin):
             self.queue = ti.queue
             self.pool = ti.pool
             self.priority_weight = ti.priority_weight
+            self.duration = ti.duration
+            self.unixname = ti.unixname
+            self.job_id = ti.job_id
+            self.operator = ti.operator
+            self.queued_dttm = ti.queued_dttm
         else:
             self.state = None
 


### PR DESCRIPTION
Retrieve queue/pool/priority_weight from db and set the attributes accordingly. This ensure that we use the value stored in db instead from code.