### PR TITLE
Merge after mutated task instance

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1272,7 +1272,7 @@ class SchedulerJob(BaseJob):
             if last_runtime is not None:
                 Stats.gauge('last_runtime.{}'.format(name), last_runtime)
             if last_run is not None:
-                unixtime = last_run.strftime("%s")
+                unixtime = int(last_run.strftime("%s"))
                 seconds_ago = (datetime.now() - last_run).total_seconds()
                 Stats.gauge('last_run.unixtime.{}'.format(name), unixtime)
                 Stats.gauge('last_run.seconds_ago.{}'.format(name), seconds_ago)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4519,6 +4519,7 @@ class DagRun(Base):
                 logging.info("Restoring task '{}' which was previously removed from DAG '{}'".format(ti, dag))
                 Stats.incr("task_restored_to_dag.{}".format(dag.dag_id), 1, 1)
                 ti.state = State.NONE
+            session.merge(ti)
 
         # check for missing tasks
         for task in dag.tasks:


### PR DESCRIPTION
For some reason in our ETL env, we need to add the `session.merge` so that the mutation is persisted to db. And that is not required in my local airflow setup (SequentialExecutor+sqlite).