### PR TITLE
Turn off browser autocomplete for search DAG

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -60,7 +60,7 @@
       <div class="col-sm-2">
       </div>
       <div class="col-sm-10">
-        <form id="search_form" class="form-inline" style="width: 100%; text-align: right;">
+        <form id="search_form" class="form-inline" style="width: 100%; text-align: right;" autocomplete="off">
             <div id="dags_filter" class="form-group" style="width: 100%;">
               <label for="dag_query" style="width:20%; text-align: right;">Search:</label>
               <input id="dag_query" type="text" class="typeahead form-control" data-provide="typeahead" style="width:50%;" value="{{search_query}}">


### PR DESCRIPTION
Currently when you are searching for a DAG in the Airflow UI, the browser (like Chrome) will provide typeahead based on your search history which blocks the typeahead support from Airflow UI. Therefore, turning off the autocomplete from the browser to respect the recommendation from airflow UI.

![Screen Shot 2020-05-15 at 10 55 37 AM](https://user-images.githubusercontent.com/6065051/82081368-03702580-969b-11ea-960e-e4c7a4b42e03.png)
