### PR TITLE
[DPTOOLS-2841] Upgrade alembic and fix invalid escape sequences

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -94,8 +94,8 @@ class CeleryExecutor(BaseExecutor):
 
         self.logger.debug(
             "Inquiring about {} celery task(s)".format(len(self.tasks)))
-        for key, async in list(self.tasks.items()):
-            state = async.state
+        for key, _async in list(self.tasks.items()):
+            state = _async.state
             if self.last_state[key] != state:
                 if state == celery_states.SUCCESS:
                     self.success(key)
@@ -110,13 +110,13 @@ class CeleryExecutor(BaseExecutor):
                     del self.tasks[key]
                     del self.last_state[key]
                 else:
-                    self.logger.info("Unexpected state: " + async.state)
-                self.last_state[key] = async.state
+                    self.logger.info("Unexpected state: " + _async.state)
+                self.last_state[key] = _async.state
 
     def end(self, synchronous=False):
         if synchronous:
             while any([
-                    async.state not in celery_states.READY_STATES
-                    for async in self.tasks.values()]):
+                    _async.state not in celery_states.READY_STATES
+                    for _async in self.tasks.values()]):
                 time.sleep(5)
         self.sync()

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -439,7 +439,7 @@ class HdfsSensor(BaseSensorOperator):
         :return:
         """
         if ignore_copying:
-            regex_builder = "^.*\.(%s$)$" % '$|'.join(ignored_ext)
+            regex_builder = r"^.*\.(%s$)$" % '$|'.join(ignored_ext)
             ignored_extentions_regex = re.compile(regex_builder)
             logging.debug('Filtering result for ignored extentions: %s in files %s', ignored_extentions_regex.pattern,
                           map(lambda x: x['path'], result))

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ def do_setup():
         zip_safe=False,
         scripts=['airflow/bin/airflow'],
         install_requires=[
-            'alembic>=0.8.3, <0.9',
+            'alembic>=1.0, <2.0',
             'blinker==1.4',
             'croniter>=0.3.8, <0.4',
             'dill>=0.2.2, <0.3',


### PR DESCRIPTION
Upgrade to a newer version of alembic and fix a few strings in the
Airflow regexes which should be raw strings to get rid of the following
DeprecationWarnings in the logs:

    /srv/venvs/service/trusty/service_venv_python3.6/src/apache-airflow/airflow/executors/celery_executor.py:97:
    DeprecationWarning: 'async' and 'await' will become reserved keywords in Python 3.7
      for key, async in list(self.tasks.items()):
    [2020-05-28 22:38:15,161] {__init__.py:60} INFO - Using executor LocalExecutor
    /srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/alembic/operations/ops.py:844:
    DeprecationWarning: invalid escape sequence \*
    /srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/alembic/operations/base.py:94:
    DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
      spec = inspect.getargspec(fn)
    /srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/alembic/util/langhelpers.py:76:
    DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
      spec = inspect.getargspec(fn)

I checked the alembic changelog [1] and didn't see anything scary
between 0.8.10 and 1.0. Here's the corresponding upstream change:
https://github.com/apache/airflow/commit/9cfeb31fc14b766a4030b66cdc191dff761730c7

[1] https://alembic.sqlalchemy.org/en/latest/changelog.html