### PR TITLE
Disable Run button in task instance page

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -139,27 +139,27 @@
             View Log
           </button>
           <hr/>
-          <button id="btn_run" type="button" class="btn btn-primary"
-            title="Runs a single task instance">
-            Run
-          </button>
-          <span class="btn-group">
-            <button id="btn_ignore_all_deps"
-              type="button" class="btn" data-toggle="button"
-              title="Ignores all non-critical dependencies, including task state and task_deps"
-              >Ignore All Deps</button>
-          </span>
-          <span class="btn-group">
-            <button id="btn_ignore_ti_state"
-              type="button" class="btn" data-toggle="button"
-              title="Ignore previous success/failure"
-              >Ignore Task State</button>
-          </span>
-          <button id="btn_ignore_task_deps"
-            type="button" class="btn" data-toggle="button"
-            title="Disregard the task-specific dependencies, e.g. status of upstream task instances and depends_on_past"
-            >Ignore Task Deps</button>
-          </span>
+<!--          <button id="btn_run" type="button" class="btn btn-primary"-->
+<!--            title="Runs a single task instance">-->
+<!--            Run-->
+<!--          </button>-->
+<!--          <span class="btn-group">-->
+<!--            <button id="btn_ignore_all_deps"-->
+<!--              type="button" class="btn" data-toggle="button"-->
+<!--              title="Ignores all non-critical dependencies, including task state and task_deps"-->
+<!--              >Ignore All Deps</button>-->
+<!--          </span>-->
+<!--          <span class="btn-group">-->
+<!--            <button id="btn_ignore_ti_state"-->
+<!--              type="button" class="btn" data-toggle="button"-->
+<!--              title="Ignore previous success/failure"-->
+<!--              >Ignore Task State</button>-->
+<!--          </span>-->
+<!--          <button id="btn_ignore_task_deps"-->
+<!--            type="button" class="btn" data-toggle="button"-->
+<!--            title="Disregard the task-specific dependencies, e.g. status of upstream task instances and depends_on_past"-->
+<!--            >Ignore Task Deps</button>-->
+<!--          </span>-->
           <hr/>
           <button id="btn_clear" type="button" class="btn btn-primary"
               title="Clearing deletes the previous state of the task instance, allowing it to get re-triggered by the scheduler or a backfill command"


### PR DESCRIPTION
The button is not idempotent and super confusing to new users which could easily trigger an additional task in the backend.

Disable the button as part of the learning of the GDPR deletion running issue.