### PR TITLE
[AIRFLOW-1614] Replace inspect.stack() with sys._getframe()

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -31,7 +31,6 @@ import getpass
 import imp
 import importlib
 import itertools
-import inspect
 import zipfile
 import jinja2
 import json
@@ -2889,7 +2888,8 @@ class DAG(BaseDag, LoggingMixin):
 
         self._description = description
         # set file location to caller source path
-        self.fileloc = inspect.getsourcefile(inspect.stack()[1][0])
+        back = sys._getframe().f_back
+        self.fileloc = back.f_code.co_filename if back else ""
         self.task_dict = dict()
         self.start_date = start_date
         self.end_date = end_date


### PR DESCRIPTION
Adapted from this commit upstream: https://github.com/apache/airflow/pull/2610:

This makes DagBag loading almost 3x faster on TARS staging.

- Before: 3m3s
- After: 1m9s

Original commit message:

    inspect.stack() is really expensive, and slows down processing of dags
    having large numbers (100s, 1000s) of subdags.