### PR TITLE
Cherry pick airflow 6576

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -671,7 +671,7 @@ class SchedulerJob(BaseJob):
                     tasks_missed_sla.append(task)
                 except AirflowException:
                     # task already deleted from DAG, skip it
-                    self.log.warning(
+                    self.logger.warning(
                         "Task %s doesn't exist in DAG anymore, skipping SLA miss notification.",
                         sla.task_id)
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -38,9 +38,11 @@ import psutil
 from sqlalchemy import Column, Integer, String, DateTime, func, Index, or_, and_
 from sqlalchemy import update
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.session import make_transient
 from tabulate import tabulate
 from tqdm import tqdm
+from typing import List
 
 from airflow import executors, models, settings
 from airflow import configuration as conf
@@ -561,6 +563,7 @@ class SchedulerJob(BaseJob):
 
     @provide_session
     def manage_slas(self, dag, session=None):
+        # type: (DAG, Session) -> None
         """
         Finding all tasks that have SLAs defined, and sending alert emails
         where needed. New SLA misses are also recorded in the database.
@@ -661,8 +664,15 @@ class SchedulerJob(BaseJob):
             """.format(bug=asciiart.bug, **locals())
             emails = []
 
+            tasks_missed_sla = []  # type: List[TaskInstance]
+            for sla in slas:
+                if sla.task_id not in dag.task_ids:
+                    session.delete(sla)
+                    self.logger.warning('Skipping SLA notification as %s no longer exists in %s',
+                                        sla.task_id, dag.dag_id)
+                else:
+                    tasks_missed_sla.append(dag.get_task(sla.task_id))
 
-            tasks_missed_sla = [dag.get_task(sla.task_id) for sla in slas]
             for t in tasks_missed_sla:
                 if t.email:
                     if isinstance(t.email, basestring):

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -667,7 +667,6 @@ class SchedulerJob(BaseJob):
             tasks_missed_sla = []  # type: List[TaskInstance]
             for sla in slas:
                 if sla.task_id not in dag.task_ids:
-                    session.delete(sla)
                     self.logger.warning('Skipping SLA notification as %s no longer exists in %s',
                                         sla.task_id, dag.dag_id)
                 else:

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -1960,7 +1960,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         self.assertEqual(len(import_errors), 0)
 
-    def test_manage_slas_remove_tasks_no_longer_exists(self):
+    def test_manage_slas_handle_tasks_no_longer_exists(self):
         session = settings.Session()
         dag_id = 'dummy'
         task_id = 'iamghost'
@@ -1978,10 +1978,3 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler = SchedulerJob(**self.default_scheduler_args)
 
         scheduler.manage_slas(dag, session=session)
-
-        cnt = session.query(models.SlaMiss).filter(
-            models.SlaMiss.dag_id == dag_id,
-            models.SlaMiss.task_id == task_id,
-        ).count()
-
-        self.assertEqual(cnt, 0)


### PR DESCRIPTION
Cherry pick https://github.com/apache/airflow/pull/7187.

When a task with SLA is deleted from a DAG after the SLA miss is logged but before the notification was sent, scheduler will crash with an AirflowException.