### PR TITLE
Selectively cherry-pick DAG tags from AIRFLOW-4026

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1607,7 +1607,7 @@ class SchedulerJob(BaseJob):
         # Save individual DAGs in the ORM and update DagModel.last_scheduled_time
         sync_time = datetime.now()
         for dag in dagbag.dags.values():
-            models.DAG.sync_to_db(dag, dag.owner, sync_time)
+            dag.sync_to_db(dag.owner, sync_time)
 
         paused_dag_ids = [dag.dag_id for dag in dagbag.dags.values()
                           if dag.is_paused]

--- a/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
+++ b/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add DagTags table
+
+Revision ID: 7939bcff74ba
+Revises: fe461863935f
+Create Date: 2020-01-07 19:39:01.247442
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7939bcff74ba'
+# Originally the down revision was fe461863935f, but
+# 127d2bf2dfa7 is our current head in the data-platform-upgrade
+# branch as of June 2020
+down_revision = '127d2bf2dfa7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply Add DagTags table"""
+    op.create_table(
+        'dag_tag',
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.ForeignKeyConstraint(['dag_id'], ['dag.dag_id'], ),
+        sa.PrimaryKeyConstraint('name', 'dag_id')
+    )
+
+
+def downgrade():
+    """Unapply Add DagTags table"""
+    op.drop_table('dag_tag')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3749,9 +3749,8 @@ class DAG(BaseDag, LoggingMixin):
 
         return run
 
-    @staticmethod
     @provide_session
-    def sync_to_db(dag, owner, sync_time, session=None):
+    def sync_to_db(self, owner, sync_time, session=None):
         """
         Save attributes about this DAG to the DB. Note that this method
         can be called for both DAGs and SubDAGs. A SubDag is actually a
@@ -3765,17 +3764,17 @@ class DAG(BaseDag, LoggingMixin):
         :return: None
         """
         orm_dag = session.query(
-            DagModel).filter(DagModel.dag_id == dag.dag_id).first()
+            DagModel).filter(DagModel.dag_id == self.dag_id).first()
         if not orm_dag:
-            orm_dag = DagModel(dag_id=dag.dag_id)
+            orm_dag = DagModel(dag_id=self.dag_id)
             logging.info("Creating ORM DAG for %s",
-                         dag.dag_id)
+                         self.dag_id)
             session.add(orm_dag)
-        if dag.is_subdag:
-            orm_dag.fileloc = dag.fileloc
+        if self.is_subdag:
+            orm_dag.fileloc = self.fileloc
         else:
-            orm_dag.fileloc = dag.full_filepath
-        orm_dag.is_subdag = dag.is_subdag
+            orm_dag.fileloc = self.full_filepath
+        orm_dag.is_subdag = self.is_subdag
         orm_dag.owners = owner
         orm_dag.is_active = True
         orm_dag.last_scheduler_run = sync_time
@@ -3783,8 +3782,8 @@ class DAG(BaseDag, LoggingMixin):
         orm_dag.tags = self.get_dagtags(session=session)
         session.commit()
 
-        for subdag in dag.subdags:
-            DAG.sync_to_db(subdag, owner, sync_time, session=session)
+        for subdag in self.subdags:
+            subdag.sync_to_db(owner, sync_time, session=session)
 
     @provide_session
     def get_dagtags(self, session=None):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -55,7 +55,7 @@ from sqlalchemy import (
 from sqlalchemy import func, or_, and_
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.dialects.mysql import LONGTEXT
-from sqlalchemy.orm import reconstructor, relationship, synonym
+from sqlalchemy.orm import backref, reconstructor, relationship, synonym
 
 from croniter import croniter
 import six
@@ -2717,6 +2717,13 @@ class BaseOperator(object):
             dag_id=dag_id,
             include_prior_dates=include_prior_dates)
 
+class DagTag(Base):
+    """
+    A tag name per dag, to allow quick filtering in the DAG view.
+    """
+    __tablename__ = "dag_tag"
+    name = Column(String(100), primary_key=True)
+    dag_id = Column(String(ID_LEN), ForeignKey('dag.dag_id'), primary_key=True)
 
 class DagModel(Base):
 
@@ -2749,6 +2756,8 @@ class DagModel(Base):
     fileloc = Column(String(2000))
     # String representing the owners
     owners = Column(String(2000))
+    # Tags for view filter
+    tags = relationship('DagTag', cascade='all,delete-orphan', backref=backref('dag'))
 
     def __repr__(self):
         return "<DAG: {self.dag_id}>".format(self=self)
@@ -2843,6 +2852,8 @@ class DAG(BaseDag, LoggingMixin):
     :param on_success_callback: Much like the ``on_failure_callback`` except
         that it is executed when the dag succeeds.
     :type on_success_callback: callable
+    :param tags: List of tags to help filtering DAGS in the UI.
+    :type tags: List[str]
     """
 
     def __init__(
@@ -2866,7 +2877,9 @@ class DAG(BaseDag, LoggingMixin):
             on_failure_callback=None,  # type: Optional[Callable]
             doc_md=None,  # type: Optional[str]
             params=None,
-            access_control=None):
+            access_control=None,
+            tags=None,  # type: Optional[List[str]]
+    ):
 
         self.user_defined_macros = user_defined_macros
         self.user_defined_filters = user_defined_filters
@@ -2939,6 +2952,7 @@ class DAG(BaseDag, LoggingMixin):
             # just make sure it looks like a dict
             for role, perms in access_control.items():
                 pass
+        self.tags = tags
 
     def __repr__(self):
         return "<DAG: {self.dag_id}>".format(self=self)
@@ -3756,6 +3770,7 @@ class DAG(BaseDag, LoggingMixin):
             orm_dag = DagModel(dag_id=dag.dag_id)
             logging.info("Creating ORM DAG for %s",
                          dag.dag_id)
+            session.add(orm_dag)
         if dag.is_subdag:
             orm_dag.fileloc = dag.fileloc
         else:
@@ -3764,11 +3779,33 @@ class DAG(BaseDag, LoggingMixin):
         orm_dag.owners = owner
         orm_dag.is_active = True
         orm_dag.last_scheduler_run = sync_time
-        session.merge(orm_dag)
+
+        orm_dag.tags = self.get_dagtags(session=session)
         session.commit()
 
         for subdag in dag.subdags:
             DAG.sync_to_db(subdag, owner, sync_time, session=session)
+
+    @provide_session
+    def get_dagtags(self, session=None):
+        """
+        Creating a list of DagTags, if one is missing from the DB, will insert.
+        :return: The DagTag list.
+        :rtype: list
+        """
+        tags = []
+        if not self.tags:
+            return tags
+
+        for name in set(self.tags):
+            tag = session.query(
+                DagTag).filter(DagTag.name == name).filter(DagTag.dag_id == self.dag_id).first()
+            if not tag:
+                tag = DagTag(name=name, dag_id=self.dag_id)
+                session.add(tag)
+            tags.append(tag)
+        session.commit()
+        return tags
 
     @staticmethod
     @provide_session

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -261,7 +261,7 @@ def initdb():
     # Save individual DAGs in the ORM
     now = datetime.utcnow()
     for dag in dagbag.dags.values():
-        models.DAG.sync_to_db(dag, dag.owner, now)
+        dag.sync_to_db(dag.owner, now)
     # Deactivate the unknown ones
     models.DAG.deactivate_unknown_dags(dagbag.dags.keys())
 


### PR DESCRIPTION
Allow tags to be defined in the DAG's `__init__` method. We don't need
the UI-related stuff yet, so I've excluded it to make the diff smaller.