### PR TITLE
Backfill reset_dagruns set DagRun state to NONE

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3409,9 +3409,13 @@ class DAG(BaseDag, LoggingMixin):
         if do_it:
             clear_task_instances(tis, session)
             if reset_dag_runs:
+                # Setting the state of DagRun to NONE instead of
+                # RUNNING to avoid reaching max_active_runs limitation
+                # during backfill.
                 self.set_dag_runs_state(session=session,
                                         start_date=start_date,
                                         end_date=end_date,
+                                        state=State.NONE,
                                         )
         else:
             count = 0

--- a/tests/models.py
+++ b/tests/models.py
@@ -251,7 +251,12 @@ class DagTest(unittest.TestCase):
         t1 = DummyOperator(task_id=task_id, dag=dag)
 
         session = settings.Session()  # type: Session
-        dagrun_1 = dag.create_dagrun(run_id=DagRun.ID_PREFIX, state=State.RUNNING, start_date=DEFAULT_DATE)
+        dagrun_1 = dag.create_dagrun(
+            run_id=DagRun.ID_PREFIX,
+            state=State.RUNNING,
+            start_date=DEFAULT_DATE,
+            execution_date=DEFAULT_DATE,
+        )
         session.merge(dagrun_1)
 
         task_instance_1 = TI(t1, execution_date=DEFAULT_DATE, state=State.RUNNING)
@@ -278,7 +283,7 @@ class DagTest(unittest.TestCase):
 
         self.assertEqual(len(task_instances), 1)
         task_instance = task_instances[0]  # type: TI
-        self.assertEqual(task_instance.state, State.SHUTDOWN)
+        self.assertEqual(task_instance.state, State.NONE)
 
     def test_render_template_field(self):
         """Tests if render_template from a field works"""


### PR DESCRIPTION
Currently when we backfill with `--reset_dagruns`, airflow would set the `DagRun`s within the backfill range to `RUNNING` state and that could cause the DAG to reach max active runs limitation [here](https://github.com/lyft/incubator-airflow/blob/899344c4e6ddee99163fd5fff84456cd11467df2/airflow/jobs.py#L1861-L1872) before backfill execution actually starts.

Thus setting the dagrun to `None` state so that it can pass the max active runs check and then Airflow would set it to `RUNNING` state afterwards.

https://jira.lyft.net/browse/DPTOOLS-2885