### PR TITLE
Default reset dagruns to False

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3358,7 +3358,7 @@ class DAG(BaseDag, LoggingMixin):
             only_running=False,
             confirm_prompt=False,
             include_subdags=True,
-            reset_dag_runs=True,
+            reset_dag_runs=False,
             dry_run=False):
         """
         Clears a set of task instances associated with the current dag for
@@ -3412,11 +3412,12 @@ class DAG(BaseDag, LoggingMixin):
                 # Setting the state of DagRun to NONE instead of
                 # RUNNING to avoid reaching max_active_runs limitation
                 # during backfill.
-                self.set_dag_runs_state(session=session,
-                                        start_date=start_date,
-                                        end_date=end_date,
-                                        state=State.NONE,
-                                        )
+                self.set_dag_runs_state(
+                    session=session,
+                    start_date=start_date,
+                    end_date=end_date,
+                    state=State.NONE,
+                )
         else:
             count = 0
             print("Bail. Nothing was cleared.")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1061,7 +1061,9 @@ class Airflow(BaseView):
             count = dag.clear(
                 start_date=start_date,
                 end_date=end_date,
-                include_subdags=recursive)
+                include_subdags=recursive,
+                reset_dag_runs=False,
+            )
 
             flash("{0} task instances have been cleared".format(count))
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -286,7 +286,7 @@ class DagTest(unittest.TestCase):
     @parameterized.expand([
         (state, State.NONE)
         for state in State.task_states if state != State.RUNNING
-    ] + [(State.RUNNING, State.SHUTDOWN)])
+    ])
     def test_clear_dag(self, ti_state_begin, ti_state_end):
         dag_id = 'test_clear_dag'
         task_id = 't1'
@@ -318,9 +318,7 @@ class DagTest(unittest.TestCase):
             TI.dag_id == dag_id,
         ).all()
 
-        self.assertEqual(len(task_instances), 1)
-        task_instance = task_instances[0]  # type: TI
-        self.assertEqual(task_instance.state, ti_state_end)
+        self.assertEqual(len(task_instances), 0)
 
     def test_render_template_field(self):
         """Tests if render_template from a field works"""


### PR DESCRIPTION
This PR fix the issue that clearing task instance results in setting `DagRun` state to `NONE`. It should be `RUNNING` instead.

By default, we should default `reset_dag_runs` flag in `DAG.clear` to `false` so that Airflow would change `DagRun` state to `RUNNING`. This fixes the issue we observed that clearing task instance on UI set the state to `NONE`.

I tried running webserver locally and cleared a task and confirmed that the dagrun will be set to `RUNNING` state.