### PR TITLE
Set DAG level owner in add_task if task.owner is NONE

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3616,6 +3616,9 @@ class DAG(BaseDag, LoggingMixin):
         elif task.end_date and self.end_date:
             task.end_date = min(task.end_date, self.end_date)
 
+        if not task.owner and 'owner' in self.default_args:
+            task.owner = self.default_args['owner']
+
         if task.task_id in self.task_dict:
             # TODO: raise an error in Airflow 2.0
             warnings.warn(


### PR DESCRIPTION
Currently there is a mismatch of how owner is assigned to the task. If the task was added to the DAG using the context manager, e.g.
```
with DAG(...) as dag:
    PythonOperator(...)
```
the `task.owner` would default to the owner provided via `default_args['owner']`.

However, if the task was added to the DAG using the `add_task` method, `task.owner` would default to `configuration.get('operators', 'DEFAULT_OWNER')`.


