### PR TITLE
Always reload DAGs when running sync_to_db

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1844,7 +1844,7 @@ def sync_perm(args): # noqa
 
 @cli_utils.action_logging
 def sync_to_db(args): # noqa
-    dagbag = DagBag(settings.DAGS_FOLDER, store_serialized_dags=settings.STORE_SERIALIZED_DAGS)
+    dagbag = DagBag(settings.DAGS_FOLDER, store_serialized_dags=False)
     for dag in dagbag.dags.values():
         dag.sync_to_db()
 


### PR DESCRIPTION
If the DagBag is initialized with `store_serialized_dags = True` then it
skips evaluating the DAG definitions on disk. We always want to eval the
DAG definitions when we run `airflow sync_to_db` - otherwise this
command is effectively a no-op.

This change explicitly sets `store_serialized_dags = False` when
initializing the DagBag so that we'll reload DAG definitions before
serializing and storing them in the database.