### PR TITLE
[DPTOOLS-2988] Use threads to sync Celery tasks

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -22,7 +22,8 @@ import os
 import subprocess
 import time
 import traceback
-from multiprocessing import Pool, cpu_count
+from multiprocessing.dummy import Pool
+from multiprocessing import cpu_count
 
 from celery import Celery
 from celery import states as celery_states


### PR DESCRIPTION
gevent doesn't play well with `multiprocessing` module, so clicking the
Run button on the web UI causes the gunicorn worker to hang with the
following stack dump:

    Thread 26486 (idle)
        _recv (multiprocessing/connection.py:379)
        _recv_bytes (multiprocessing/connection.py:407)
        recv_bytes (multiprocessing/connection.py:216)
        get (multiprocessing/queues.py:335)
        worker (multiprocessing/pool.py:108)
        run (multiprocessing/process.py:93)
        _bootstrap (multiprocessing/process.py:258)
        _launch (multiprocessing/popen_fork.py:73)
        __init__ (multiprocessing/popen_fork.py:19)
        _Popen (multiprocessing/context.py:277)
        start (multiprocessing/process.py:105)
        _repopulate_pool (multiprocessing/pool.py:239)
        __init__ (multiprocessing/pool.py:174)
        Pool (multiprocessing/context.py:119)
        sync (airflow/executors/celery_executor.py:247)
        heartbeat (airflow/executors/base_executor.py:134)
        run (airflow/www/views.py:1162)
        wrapper (airflow/www/utils.py:337)
        wrapper (airflow/www/utils.py:290)
        decorated_view (flask_login/utils.py:258)
        _run_view (flask_admin/base.py:368)
        inner (flask_admin/base.py:69)
        dispatch_request (flask/app.py:1935)
        full_dispatch_request (flask/app.py:1949)
        wsgi_app (flask/app.py:2446)
        __call__ (flask/app.py:2463)
        __call__ (werkzeug/middleware/dispatcher.py:66)
        handle_request (gunicorn/workers/async.py:103)
        handle_request (gunicorn/workers/ggevent.py:152)
        handle (gunicorn/workers/async.py:38)
        _handle_and_close_when_done (gevent/baseserver.py:26)

See https://github.com/lyft/python-lyft-etl/pull/414 for a similar fix
in the LyftCeleryExecutor and a detailed explanation.