### PR TITLE
Instrument duration of scheduler loop

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1471,6 +1471,7 @@ class SchedulerJob(BaseJob):
             self.log.debug(
                 "Ran scheduling loop in %.2f seconds",
                 loop_duration)
+            Stats.timing('scheduler.loop_duration_sec', loop_duration)
 
             if not is_unit_test:
                 self.log.debug("Sleeping for %.2f seconds", self._processor_poll_interval)


### PR DESCRIPTION
According to [1], sensors with `mode=reschedule` break when the duration
of the scheduler loop >= the reschedule interval.

Let's add some instrumentation to identify the maximum time we spend in
the scheduling loop, as this number (plus some margin of safety)  will
be the lower bound on the reschedule interval until the race condition
is fixed.

[1] https://issues.apache.org/jira/browse/AIRFLOW-5071?focusedCommentId=17206032&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17206032