### PR TITLE
[AIRFLOW-5071] Fix for race condition with mode=reschedule

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -43,7 +43,7 @@ from airflow.configuration import conf
 from airflow import executors, models, settings
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.jobs.base_job import BaseJob
-from airflow.models import DagRun, SlaMiss, errors
+from airflow.models import DagRun, SlaMiss, TaskReschedule, errors
 from airflow.settings import Stats
 from airflow.ti_deps.dep_context import DepContext, SCHEDULEABLE_STATES, SCHEDULED_DEPS
 from airflow.ti_deps.deps.pool_slots_available_dep import STATES_TO_COUNT_AS_RUNNING
@@ -1337,24 +1337,40 @@ class SchedulerJob(BaseJob):
 
                 # TODO: should we fail RUNNING as well, as we do in Backfills?
                 if ti.try_number == try_number and ti.state == State.QUEUED:
-                    msg = ("Executor reports task instance {} finished ({}) "
-                           "although the task says its {}. Was the task "
-                           "killed externally?".format(ti, state, ti.state))
-                    Stats.incr('scheduler.tasks.killed_externally')
-                    self.log.error(msg)
-                    try:
-                        simple_dag = simple_dag_bag.get_dag(dag_id)
-                        dagbag = models.DagBag(simple_dag.full_filepath)
-                        dag = dagbag.get_dag(dag_id)
-                        ti.task = dag.get_task(task_id)
-                        ti.handle_failure(msg)
-                    except Exception:
-                        self.log.error("Cannot load the dag bag to handle failure for %s"
-                                       ". Setting task to FAILED without callbacks or "
-                                       "retries. Do you have enough resources?", ti)
-                        ti.state = State.FAILED
-                        session.merge(ti)
-                        session.commit()
+                    task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                    if task_reschedules:
+                        # Hacky workaround for https://issues.apache.org/jira/browse/AIRFLOW-5071
+                        #
+                        # The sensors' reschedule timeout has already
+                        # expired and the scheduler has re-enqueued
+                        # the task. The executor event we're seeing
+                        # here actually corresponds to the previous
+                        # attempt. It has the same try_number because
+                        # Sensors with mode=reschedule don't bump the
+                        # try_number on every reschedule attempt
+                        msg = ("Executor reports sensor {} finished ({}), "
+                               "but the scheduler already re-enqueued it. "
+                               "Running it again...")
+                        Stats.incr('scheduler.tasks.already_rescheduled')
+                    else:
+                        msg = ("Executor reports task instance {} finished ({}) "
+                               "although the task says its {}. Was the task "
+                               "killed externally?".format(ti, state, ti.state))
+                        Stats.incr('scheduler.tasks.killed_externally')
+                        self.log.error(msg)
+                        try:
+                            simple_dag = simple_dag_bag.get_dag(dag_id)
+                            dagbag = models.DagBag(simple_dag.full_filepath)
+                            dag = dagbag.get_dag(dag_id)
+                            ti.task = dag.get_task(task_id)
+                            ti.handle_failure(msg)
+                        except Exception:
+                            self.log.error("Cannot load the dag bag to handle failure for %s"
+                                        ". Setting task to FAILED without callbacks or "
+                                        "retries. Do you have enough resources?", ti)
+                            ti.state = State.FAILED
+                            session.merge(ti)
+                            session.commit()
 
     def _execute(self):
         self.log.info("Starting the scheduler")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -42,9 +42,10 @@ from airflow.configuration import conf
 from airflow.executors import BaseExecutor
 from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.models import DAG, DagBag, DagModel, DagRun, Pool, SlaMiss, \
-    TaskInstance as TI, errors
+    TaskInstance as TI, TaskReschedule, errors
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.dag_processing import SimpleDag, SimpleDagBag, list_py_file_paths
 from airflow.utils.dates import days_ago
@@ -219,6 +220,53 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertEqual(ti1.state, State.SUCCESS)
 
         mock_stats_incr.assert_called_once_with('scheduler.tasks.killed_externally')
+
+    @mock.patch('airflow.settings.Stats.incr')
+    def test_process_rescheduled_sensor_in_queued_state(self, mock_stats_incr):
+
+        class DummySensor(BaseSensorOperator):
+            def __init__(self, **kwargs):
+                super(DummySensor, self).__init__(**kwargs)
+
+            def poke(self, context):
+                return False
+
+        dag = DAG(dag_id="test_rescheduled_sensor", start_date=DEFAULT_DATE)
+        dagbag = self._make_simple_dag_bag([dag])
+        sensor = DummySensor(
+            task_id="dummy_task",
+            mode="reschedule",
+            dag=dag,
+        )
+
+        session = settings.Session()
+        ti = TI(sensor, DEFAULT_DATE)
+        session.merge(ti)
+        session.commit()
+
+        # poke() returns False, so reschedule
+        sensor.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        task_reschedules = TaskReschedule.find_for_task_instance(ti, session)
+        self.assertEqual(len(task_reschedules), 1)
+        ti.refresh_from_db()
+        self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
+
+        # Reschedule timeout expires, scheduler re-enqueues...
+        ti.state = State.QUEUED
+        session.merge(ti)
+        session.commit()
+
+        scheduler = SchedulerJob()
+        executor = MockExecutor(do_update=False)
+        # Executor reports success from previous attempt, but we
+        # already re-enqueued the TI
+        executor.event_buffer[ti.key] = State.SUCCESS
+        scheduler.executor = executor
+
+        scheduler._process_executor_events(simple_dag_bag=dagbag)
+        ti.refresh_from_db()
+        self.assertEqual(ti.state, State.QUEUED)
+        mock_stats_incr.assert_called_once_with('scheduler.tasks.already_rescheduled')
 
     def test_execute_task_instances_is_paused_wont_execute(self):
         dag_id = 'SchedulerJobTest.test_execute_task_instances_is_paused_wont_execute'


### PR DESCRIPTION
This is broken upstream - see
https://issues.apache.org/jira/browse/AIRFLOW-5071

This fix feels like a hack, so I'm not sure that it makes a good
candidate for sending upstream as-is. If this works, I'll at least post
on update on the issue and let the community decide if this is worth
upstreaming.

Summary of the race condition: if the reschedule interval is shorter
than the duration of the scheduling loop, then a Sensor TI can
transition from RUNNING -> UP_FOR_RESCHEDULE -> QUEUED all before the
main scheduler loop can process the "task succeeded" event from the
executor.

If this happens, then the scheduler will see an event saying
"task succeeded" for a TI that's in state QUEUED, so it will mark the
task as failed and the user will see an error in the logs like:

    Executor reports task instance <TaskInstance: XXX [queued]> finished
    (success) although the task says its QUEUED. Was the task killed
    externally?

Instead, we should check and see if the TaskInstance is a sensor that
has been rescheduled. If it is, then this situation is expected and we
can just ignore it.

Here's the sequence of events in a little more detail:

1. [DagFileProcessorAgent] process_file() moves TI from NONE -> SCHEDULED
2. [SchedulerJob] _validate_and_run() -> _process_and_execute() -> _execute_task_instances(): moves TI from SCHEDULED -> QUEUED, sends to executor
3. [SchedulerJob] _validate_and_run() -> _process_executor_events() finishes without seeing any relevant events, scheduling loop restarts
4. [worker] Executor pokes, sets TI state to UP_FOR_RESCHEDULE and sends TI.event=SUCCESS
5. TI's reschedule interval expires, now eligble for rescheduling
6. [DagFileProcessorAgent] process_file() moves TI from UP_FOR_RESCHEDULE -> SCHEDULED
7. [SchedulerJob] SchedulerJob._validate_and_run() -> _process_and_execute() -> _execute_task_instances() -> moves TI from SCHEDULED -> QUEUED, sends to executor
8. [SchedulerJob] _validate_and_run() -> _process_executor_events() finally sees TI.event=SUCCESS from the previous attempt, but now TI.state == QUEUED. Oh no!