### PR TITLE
Ensure jinjia templating work with task fields

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -923,8 +923,6 @@ class TaskInstance(Base, LoggingMixin):
         actual_start_date = timezone.utcnow()
         try:
             if not mark_success:
-                context = self.get_template_context()
-
                 task_copy = copy.copy(task)
 
                 # Sensors in `poke` mode can block execution of DAGs when running
@@ -948,7 +946,9 @@ class TaskInstance(Base, LoggingMixin):
 
                 start_time = time.time()
 
+                context = self.get_template_context()
                 self.render_templates(context=context)
+
                 task_copy.pre_execute(context=context)
 
                 # If a timeout is specified for the task, make it fail

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1184,6 +1184,35 @@ class TaskInstanceTest(unittest.TestCase):
         ti.set_duration()
         self.assertIsNone(ti.duration)
 
+    def test_recursive_templating_with_task_fields(self):
+        dag = DAG('test_recursive_templating', start_date=DEFAULT_DATE,
+                  end_date=DEFAULT_DATE + datetime.timedelta(days=10))
+        _arg = 'test_{{task.task_id}}'
+        _kwarg = '{{task.op_args[0]}}'
+
+        def print_nested_template(arg, kwarg):
+            assert kwarg == 'test_nested_render'
+            assert arg == 'test_nested_render'
+
+        task = PythonOperator(
+            task_id='nested_render',
+            python_callable=print_nested_template,
+            op_args=[_arg, ],
+            op_kwargs={
+                'kwarg': _kwarg,
+            },
+            dag=dag
+        )
+
+        ti = TI(task=task, execution_date=datetime.datetime.now())
+        ti.state = State.RUNNING
+        session = settings.Session()
+        session.merge(ti)
+        session.commit()
+
+        ti._run_raw_task()
+
+
     def test_success_callbak_no_race_condition(self):
         class CallbackWrapper(object):
             def wrap_task_instance(self, ti):


### PR DESCRIPTION
Previously we create a `context_template` (which includes a task object) before we make a copy of the task object. We then run render_template on the new copy of the object. However the context_template still holds the old task object, which is not getting rendered. Therefore, if you have macros that references task fields that requires rendering, it ends up not getting rendered.

This PR simply ensures that the `context_template` holds the latest copy of the task object.