### PR TITLE
Fix task not found if task removed

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -805,7 +805,11 @@ class SchedulerJob(BaseJob):
             # every task (in ti.is_runnable). This is also called in
             # update_state above which has already checked these tasks
             for ti in tis:
-                task = dag.get_task(ti.task_id)
+                try:
+                    task = dag.get_task(ti.task_id)
+                except TaskNotFound as e:
+                    self.log.exception('Failed to find corresponding tasks: %s', ti.task_id)
+                    continue
 
                 # fixme: ti.task is transient but needs to be set
                 ti.task = task


### PR DESCRIPTION
If the task was removed after the task instance is created, it can fail the loop due to task not found.