### PR TITLE
Halve the sleep time between scheduler run loops

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1508,8 +1508,8 @@ class SchedulerJob(BaseJob):
                               " have been processed {} times".format(self.num_runs))
                 break
 
-            if loop_duration < 1 and not is_unit_test:
-                sleep_length = 1 - loop_duration
+            if loop_duration < 0.5 and not is_unit_test:
+                sleep_length = 0.5 - loop_duration
                 self.log.debug(
                     "Sleeping for {0:.2f} seconds to prevent excessive logging"
                     .format(sleep_length))


### PR DESCRIPTION
https://jira.lyft.net/projects/DATAHELP/queues/custom/274/DATAHELP-4272
Based on our logging, (https://lyft.wavefront.com/u/69xrF47n2T?t=lyft), we run once a minute with a p999 of like 4 seconds, so if we're wasting like 92% of our time when we could
be scheduling tasks
