### PR TITLE
Enable tasks to log in Kyte

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -786,6 +786,11 @@ class TaskInstance(Base, LoggingMixin):
         # value that needs to be stored in the db.
         self.executor_config = task.executor_config
         self.operator = task.task_type
+        # https://github.com/apache/airflow/discussions/21021 - not fully sure I understand this issue - specifically
+        # why only certain setups run into (found more instances on the Slack, but astronomer folk never hit it, which
+        # confuses me. Not sure if this effects Airflow 2.3, so not going to push this upstream yet, but let's keep this
+        # in mind.
+        self._log = logging.getLogger('airflow.task')
 
     @provide_session
     def clear_xcom_data(self, session=None):


### PR DESCRIPTION
Confirmed that this is also broken on staging: https://airflow-staging.lyft.net/log\?dag_id\=verity_demo_quality_check\&task_id\=verity_demo_check_non_blocking\&execution_date\=2022-07-25T14%3A00%3A00%2B00%3A00 (staging logging might have more issues as well, suspicious of the color mods, might be console logging?

Based on this github thread: https://github.com/apache/airflow/discussions/21021 which I confirmed fixed it in Kyte
Related DATAHELP: https://jira.lyft.net/projects/DATAHELP/queues/custom/274/DATAHELP-5461