### PR TITLE
add metastore table to record cross dag dependencies based on xcom and variable

### DIFF
--- a/airflow/models/crossdagcommunication.py
+++ b/airflow/models/crossdagcommunication.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm.session import Session
 
 from airflow.models.base import Base
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -21,7 +22,15 @@ class CrossDagComm(Base, LoggingMixin):
     target_task_id = Column(String(250))
     timestamp = Column(UtcDateTime, default=timezone.utcnow)
 
-    def __init__(self, type, key=None, source_dag_id=None, source_task_id=None, target_dag_id=None, target_task_id=None, **kwargs):
+    def __init__(
+        self, 
+        type: str, 
+        key: str=None, 
+        source_dag_id: str=None, 
+        source_task_id: str=None, 
+        target_dag_id: str=None, 
+        target_task_id: str=None, 
+    ):
         self.type = type
         self.key = key
         self.source_dag_id = source_dag_id
@@ -31,7 +40,16 @@ class CrossDagComm(Base, LoggingMixin):
     
     @classmethod
     @provide_session
-    def add(cls, type, key=None, source_dag_id=None, source_task_id=None, target_dag_id=None, target_task_id=None, session=None):
+    def add(
+        cls, 
+        type: str, 
+        key: str=None, 
+        source_dag_id: str=None, 
+        source_task_id: str=None, 
+        target_dag_id: str=None, 
+        target_task_id: str=None, 
+        session: Session=None
+    ):
         """
         Add a new entry to the cross_dag_communication table
         :param key: key of the entry
@@ -39,4 +57,3 @@ class CrossDagComm(Base, LoggingMixin):
         """
         session.add(cls(type, key, source_dag_id, source_task_id, target_dag_id, target_task_id))
         session.flush()
-

--- a/airflow/models/crossdagcommunication.py
+++ b/airflow/models/crossdagcommunication.py
@@ -1,0 +1,42 @@
+from sqlalchemy import Column, Integer, String
+
+from airflow.models.base import Base
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils import timezone
+from airflow.utils.sqlalchemy import UtcDateTime
+from airflow.utils.session import provide_session
+
+
+class CrossDagComm(Base, LoggingMixin):
+    """Used to actively log events to the database"""
+
+    __tablename__ = "cross_dag_communication"
+
+    id = Column(Integer, primary_key=True)
+    type = Column(String(10))
+    key = Column(String(250))
+    source_dag_id = Column(String(250))
+    source_task_id = Column(String(250))
+    target_dag_id = Column(String(250))
+    target_task_id = Column(String(250))
+    timestamp = Column(UtcDateTime, default=timezone.utcnow)
+
+    def __init__(self, type, key=None, source_dag_id=None, source_task_id=None, target_dag_id=None, target_task_id=None, **kwargs):
+        self.type = type
+        self.key = key
+        self.source_dag_id = source_dag_id
+        self.source_task_id = source_task_id
+        self.target_dag_id = target_dag_id
+        self.target_task_id = target_task_id
+    
+    @classmethod
+    @provide_session
+    def add(cls, type, key=None, source_dag_id=None, source_task_id=None, target_dag_id=None, target_task_id=None, session=None):
+        """
+        Add a new entry to the cross_dag_communication table
+        :param key: key of the entry
+        :param value: value of the entry
+        """
+        session.add(cls(type, key, source_dag_id, source_task_id, target_dag_id, target_task_id))
+        session.flush()
+

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -98,6 +98,7 @@ from airflow.exceptions import (
     XComForMappingNotPushed,
 )
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
+from airflow.models.crossdagcommunication import CrossDagComm
 from airflow.models.log import Log
 from airflow.models.param import ParamsDict
 from airflow.models.taskfail import TaskFail
@@ -2462,6 +2463,19 @@ class TaskInstance(Base, LoggingMixin):
         """
         if dag_id is None:
             dag_id = self.dag_id
+
+        try:
+            if dag_id != self.dag_id:
+                CrossDagComm.add(
+                    type="xcom", 
+                    key=key, 
+                    source_dag_id=dag_id, 
+                    source_task_id=", ".join(task_ids), 
+                    target_dag_id=self.dag_id, 
+                    target_task_id=self.task_id
+                    )
+        except AirflowException:
+            logging.warning("Failed to add record to CrossDagComm table")
 
         query = XCom.get_many(
             key=key,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2470,7 +2470,7 @@ class TaskInstance(Base, LoggingMixin):
                     type="xcom", 
                     key=key, 
                     source_dag_id=dag_id, 
-                    source_task_id=", ".join(task_ids), 
+                    source_task_id=str(task_ids), 
                     target_dag_id=self.dag_id, 
                     target_task_id=self.task_id
                     )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post36'
+version = '2.3.4.post37'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
## Description:
- created new metastore table for migration: cross_dag_communication
This table tracks both cross-DAG XCom pulls and shared Variable usage. It logs the communication type, key, and involved DAGs/tasks.
```
| Column          | Type        | Description                               |
|-----------------|-------------|-------------------------------------------|
| `id`            | `INT`       | Primary key                               |
| `type`          | `VARCHAR`   | Communication type (`XCom` or `Variable`) |
| `key`           | `VARCHAR`   | `XCom` or `Variable` key                  |
| `source_dag_id` | `VARCHAR`   | Source DAG ID                             |
| `source_task_id`| `VARCHAR`   | Source Task ID (for `XCom`)               |
| `target_dag_id` | `VARCHAR`   | Target DAG ID                             |
| `target_task_id`| `VARCHAR`   | Target Task ID (for `XCom`)               |
| `timestamp`     | `TIMESTAMP` | Timestamp of the communication            |
```
- edited Variable.get, Variable.set functions to record all push/pull transactions to Variable
- edited ti.xcom_pull function to record all cross dag xcom pulls

## How do we analyze cross dag communication from this table?
table data:
![Screenshot 2024-09-12 at 5 45 05 PM](https://github.com/user-attachments/assets/bb4262fa-19e8-4870-8611-4114789de9a4)
query to run:
```
with variable_pulls as (
	select key, target_dag_id
	from cross_dag_communication
	where type = 'variable'
	and target_dag_id is not null 
	group by 1, 2
),
variable_pushes as (
	select key, source_dag_id
	from cross_dag_communication
	where type = 'variable'
	and source_dag_id is not null 
	group by 1, 2
),
cross_dag_vars as (
	select pull.key, push.source_dag_id, pull.target_dag_id
	from variable_pulls pull
	inner join variable_pushes push
	on pull.key = push.key
	and pull.target_dag_id <> push.source_dag_id
)
select key, source_dag_id, target_dag_id
from cross_dag_communication 
where type = 'xcom'
group by 1, 2, 3
union 
select key, source_dag_id, target_dag_id
from cross_dag_vars
```
analysis result:
![Screenshot 2024-09-13 at 10 36 28 AM](https://github.com/user-attachments/assets/b533a2d1-4fee-4f2b-bfca-d0100540742b)


## Deploy:

need to run this create table statement in airflow metastore staging/prod:
```
CREATE TABLE cross_dag_communication (
    id SERIAL PRIMARY KEY,
    type VARCHAR(10),
    key VARCHAR(250),
    source_dag_id VARCHAR(250),
    source_task_id VARCHAR(250),
    target_dag_id VARCHAR(250),
    target_task_id VARCHAR(250),
    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
);

```

## Testing:
kyte:
![Screenshot 2024-09-12 at 5 45 05 PM](https://github.com/user-attachments/assets/bb4262fa-19e8-4870-8611-4114789de9a4)

