### PR TITLE
Catch error on log loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post38'
+version = '2.3.4.post39'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Currently even when there is an error when doing the request to` /get_logs_with_metadata` endpoint, **the UI end does not catch it**. As a result, the spinning wheel remains, leaving the user waiting in the hope that the logs will load eventually.

<img width="572" alt="Screenshot 2024-09-27 at 10 55 29 a m" src="https://github.com/user-attachments/assets/f6eb5ae2-f6f5-4944-a831-bd09a19f17a6">


This PR catches that error and shows the user the alternative to use kibana to see the logs together with the link pointing to that specific log.

Before (spinning forever...):

<img width="920" alt="Screenshot 2024-09-27 at 10 34 10 a m" src="https://github.com/user-attachments/assets/9c42466d-30a0-485b-b89d-e3a12ce9b9a4">

After (once the endpoint failed):

<img width="923" alt="Screenshot 2024-09-27 at 10 29 50 a m" src="https://github.com/user-attachments/assets/62fe1997-0aca-4115-b0e5-595fd55f02a4">

