### PR TITLE
Backport TI updated_at column from 2.5.0

### DIFF
--- a/airflow/migrations/versions/0118_2_5_0_add_updated_at_to_dagrun_and_ti.py
+++ b/airflow/migrations/versions/0118_2_5_0_add_updated_at_to_dagrun_and_ti.py
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add updated_at column to DagRun and TaskInstance
+
+Revision ID: ee8d93fcc81e
+Revises: ecb43d2a1842
+Create Date: 2022-09-08 19:08:37.623121
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from airflow.migrations.db_types import TIMESTAMP
+
+# revision identifiers, used by Alembic.
+revision = 'ee8d93fcc81e'
+down_revision = 'ecb43d2a1842'
+branch_labels = None
+depends_on = None
+airflow_version = '2.5.0'
+
+
+def upgrade():
+    """Apply add updated_at column to DagRun and TaskInstance"""
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.add_column(sa.Column('updated_at', TIMESTAMP, default=sa.func.now))
+
+    with op.batch_alter_table('dag_run') as batch_op:
+        batch_op.add_column(sa.Column('updated_at', TIMESTAMP, default=sa.func.now))
+
+
+def downgrade():
+    """Unapply add updated_at column to DagRun and TaskInstance"""
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.drop_column('updated_at')
+
+    with op.batch_alter_table('dag_run') as batch_op:
+        batch_op.drop_column('updated_at')

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -125,6 +125,7 @@ class DagRun(Base, LoggingMixin):
         ForeignKey("log_template.id", name="task_instance_log_template_id_fkey", ondelete="NO ACTION"),
         default=select([func.max(LogTemplate.__table__.c.id)]),
     )
+    updated_at = Column(UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow)
 
     # Remove this `if` after upgrading Sphinx-AutoAPI
     if not TYPE_CHECKING and "BUILDING_AIRFLOW_DOCS" in os.environ:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -479,7 +479,7 @@ class TaskInstance(Base, LoggingMixin):
     queued_by_job_id = Column(Integer)
     pid = Column(Integer)
     executor_config = Column(ExecutorConfigType(pickler=dill))
-
+    updated_at = Column(UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow)
     external_executor_id = Column(String(ID_LEN, **COLLATION_ARGS))
 
     # The trigger to resume on if we are in state DEFERRED

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2378,6 +2378,7 @@ class TestTaskInstance:
             "trigger_id": None,
             "next_kwargs": None,
             "next_method": None,
+            "updated_at": None,
         }
         # Make sure we aren't missing any new value in our expected_values list.
         expected_keys = {f"task_instance.{key.lstrip('_')}" for key in expected_values}


### PR DESCRIPTION
New column name will be useful to query tasks stuck in scheduled state.
https://github.com/apache/airflow/pull/26252