### PR TITLE
Update migration revision

### DIFF
--- a/airflow/migrations/versions/0118_2_5_0_add_updated_at_to_dagrun_and_ti.py
+++ b/airflow/migrations/versions/0118_2_5_0_add_updated_at_to_dagrun_and_ti.py
@@ -19,7 +19,7 @@
 """Add updated_at column to DagRun and TaskInstance
 
 Revision ID: ee8d93fcc81e
-Revises: ecb43d2a1842
+Revises: f5fcbda3e651
 Create Date: 2022-09-08 19:08:37.623121
 
 """
@@ -33,7 +33,7 @@ from airflow.migrations.db_types import TIMESTAMP
 
 # revision identifiers, used by Alembic.
 revision = 'ee8d93fcc81e'
-down_revision = 'ecb43d2a1842'
+down_revision = 'f5fcbda3e651'
 branch_labels = None
 depends_on = None
 airflow_version = '2.5.0'

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post41'
+version = '2.3.4.post42'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)


### PR DESCRIPTION
Error while runing dagbag_test:

```
UserWarning: Revision ecb43d2a1842 referenced from ecb43d2a1842 -> ee8d93fcc81e (head), 
Add updated_at column to DagRun and TaskInstance is not present
```