### PR TITLE
Remove airflowinfra.multi_cluster_utils import

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -123,11 +123,8 @@ class DagBag(LoggingMixin):
         self.is_tars = "tars" in os.environ.get("SERVICE", "")
         self.is_kyte = "kyte" in os.environ.get("SERVICE", "")
 
-        if self.service_instance == "production" and not self.is_tars and not self.is_kyte:
-
-            from airflowinfra.multi_cluster_utils import get_cluster_id_from_env
-            
-            self.cluster_id = get_cluster_id_from_env()
+        if self.service_instance == "production" and not self.is_tars and not self.is_kyte:            
+            self.cluster_id = 999  # Default Airflow 2 cluster_id
 
         self.dags: Dict[str, DAG] = {}
         # the file's last modified timestamp when we last read it

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ my_dir = dirname(__file__)
 def airflow_test_suite() -> unittest.TestSuite:
     """Test suite for Airflow tests"""
     test_loader = unittest.TestLoader()
-    test_suite = test_loader.discover(
-        os.path.join(my_dir, 'tests'), pattern='test_*.py')
+    test_suite = test_loader.discover(os.path.join(my_dir, 'tests'), pattern='test_*.py')
     return test_suite
 
 
@@ -113,8 +112,7 @@ class CompileAssets(Command):
     def run(self) -> None:
         """Run a command to compile and build assets."""
         www_dir = AIRFLOW_SOURCES_ROOT / "airflow" / "www"
-        subprocess.check_call(
-            ['yarn', 'install', '--frozen-lockfile'], cwd=str(www_dir))
+        subprocess.check_call(['yarn', 'install', '--frozen-lockfile'], cwd=str(www_dir))
         subprocess.check_call(['yarn', 'run', 'build'], cwd=str(www_dir))
 
 
@@ -157,12 +155,10 @@ def git_version(version_: str) -> str:
         try:
             repo = git.Repo(os.path.join(*[my_dir, '.git']))
         except git.NoSuchPathError:
-            logger.warning(
-                '.git directory not found: Cannot compute the git version')
+            logger.warning('.git directory not found: Cannot compute the git version')
             return ''
         except git.InvalidGitRepositoryError:
-            logger.warning(
-                'Invalid .git directory not found: Cannot compute the git version')
+            logger.warning('Invalid .git directory not found: Cannot compute the git version')
             return ''
     except ImportError:
         logger.warning('gitpython not found: Cannot compute the git version.')
@@ -236,8 +232,7 @@ azure = [
     'azure-mgmt-datalake-store>=0.5.0',
     'azure-mgmt-resource>=2.2.0',
     # limited due to https://github.com/Azure/azure-sdk-for-python/pull/18801  implementation released in 12.9
-    # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations
-    'azure-storage-blob',
+    'azure-storage-blob',  # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations
     'azure-storage-common>=2.1.0',
     'azure-storage-file>=2.1.0',
     # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191
@@ -521,8 +516,7 @@ redis = [
     # TODO: upgrade to support redis package >=4
     'redis~=3.2',
 ]
-salesforce = ['simple-salesforce>=1.0.0',
-              'tableauserverclient', pandas_requirement]
+salesforce = ['simple-salesforce>=1.0.0', 'tableauserverclient', pandas_requirement]
 samba = [
     'smbprotocol>=1.5.0',
 ]
@@ -669,8 +663,7 @@ devel_only = [
     'yamllint',
 ]
 
-devel = cgroups + devel_only + doc + kubernetes + \
-    mypy_dependencies + mysql + pandas + password
+devel = cgroups + devel_only + doc + kubernetes + mypy_dependencies + mysql + pandas + password
 devel_hadoop = devel + hdfs + hive + kerberos + presto + webhdfs
 
 # Dict of all providers which are part of the Apache Airflow repository together with their requirements
@@ -767,8 +760,7 @@ CORE_EXTRAS_REQUIREMENTS: Dict[str, List[str]] = {
     'async': async_packages,
     'celery': celery,  # also has provider, but it extends the core with the CeleryExecutor
     'cgroups': cgroups,
-    # also has provider, but it extends the core with the KubernetesExecutor
-    'cncf.kubernetes': kubernetes,
+    'cncf.kubernetes': kubernetes,  # also has provider, but it extends the core with the KubernetesExecutor
     'dask': dask,
     'deprecated_api': deprecated_api,
     'github_enterprise': flask_appbuilder_oauth,
@@ -848,8 +840,7 @@ def add_extras_for_all_deprecated_aliases() -> None:
     for alias, extra in EXTRAS_DEPRECATED_ALIASES.items():
         requirements = EXTRAS_REQUIREMENTS.get(extra) if extra != '' else []
         if requirements is None:
-            raise Exception(
-                f"The extra {extra} is missing for deprecated alias {alias}")
+            raise Exception(f"The extra {extra} is missing for deprecated alias {alias}")
         EXTRAS_REQUIREMENTS[alias] = requirements
 
 
@@ -900,13 +891,11 @@ ALL_DB_PROVIDERS = [
 ]
 
 # Special requirements for all database-related providers. They are de-duplicated.
-all_dbs = list(
-    {req for db_provider in ALL_DB_PROVIDERS for req in PROVIDERS_REQUIREMENTS[db_provider]})
+all_dbs = list({req for db_provider in ALL_DB_PROVIDERS for req in PROVIDERS_REQUIREMENTS[db_provider]})
 
 # Requirements for all "user" extras (no devel). They are de-duplicated. Note that we do not need
 # to separately add providers requirements - they have been already added as 'providers' extras above
-_all_requirements = list(
-    {req for extras_reqs in EXTRAS_REQUIREMENTS.values() for req in extras_reqs})
+_all_requirements = list({req for extras_reqs in EXTRAS_REQUIREMENTS.values() for req in extras_reqs})
 
 # All user extras here
 EXTRAS_REQUIREMENTS["all"] = _all_requirements
@@ -966,8 +955,7 @@ devel_ci = devel_all
 # They can be use to install some predefined set of dependencies.
 EXTRAS_REQUIREMENTS["doc"] = doc
 EXTRAS_REQUIREMENTS["devel"] = devel  # devel already includes doc
-# devel_hadoop already includes devel
-EXTRAS_REQUIREMENTS["devel_hadoop"] = devel_hadoop
+EXTRAS_REQUIREMENTS["devel_hadoop"] = devel_hadoop  # devel_hadoop already includes devel
 EXTRAS_REQUIREMENTS["devel_all"] = devel_all
 EXTRAS_REQUIREMENTS["devel_ci"] = devel_ci
 
@@ -1042,16 +1030,13 @@ class AirflowDistribution(Distribution):
             self.install_requires = [
                 req for req in self.install_requires if not req.startswith('apache-airflow-providers-')
             ]
-            provider_yaml_files = glob.glob(
-                "airflow/providers/**/provider.yaml", recursive=True)
+            provider_yaml_files = glob.glob("airflow/providers/**/provider.yaml", recursive=True)
             for provider_yaml_file in provider_yaml_files:
-                provider_relative_path = relpath(
-                    provider_yaml_file, os.path.join(my_dir, "airflow"))
+                provider_relative_path = relpath(provider_yaml_file, os.path.join(my_dir, "airflow"))
                 self.package_data['airflow'].append(provider_relative_path)
         else:
             self.install_requires.extend(
-                [get_provider_package_from_package_id(
-                    package_id) for package_id in PREINSTALLED_PROVIDERS]
+                [get_provider_package_from_package_id(package_id) for package_id in PREINSTALLED_PROVIDERS]
             )
 
 
@@ -1094,8 +1079,7 @@ def replace_extra_requirement_with_provider_packages(extra: str, providers: List
     """
     if extra in ['cncf.kubernetes', 'kubernetes', 'celery']:
         EXTRAS_REQUIREMENTS[extra].extend(
-            [get_provider_package_from_package_id(
-                package_name) for package_name in providers]
+            [get_provider_package_from_package_id(package_name) for package_name in providers]
         )
     else:
         EXTRAS_REQUIREMENTS[extra] = [
@@ -1113,8 +1097,7 @@ def add_provider_packages_to_extra_requirements(extra: str, providers: List[str]
     :param providers: list of provider ids
     """
     EXTRAS_REQUIREMENTS[extra].extend(
-        [get_provider_package_from_package_id(
-            package_name) for package_name in providers]
+        [get_provider_package_from_package_id(package_name) for package_name in providers]
     )
 
 
@@ -1144,28 +1127,23 @@ class Develop(develop_orig):
     """Forces removal of providers in editable mode."""
 
     def run(self) -> None:  # type: ignore
-        self.announce(
-            'Installing in editable mode. Uninstalling provider packages!', level=log.INFO)
+        self.announce('Installing in editable mode. Uninstalling provider packages!', level=log.INFO)
         # We need to run "python3 -m pip" because it might be that older PIP binary is in the path
         # And it results with an error when running pip directly (cannot import pip module)
         # also PIP does not have a stable API so we have to run subprocesses ¯\_(ツ)_/¯
         try:
             installed_packages = (
-                subprocess.check_output(
-                    ["python3", "-m", "pip", "freeze"]).decode().splitlines()
+                subprocess.check_output(["python3", "-m", "pip", "freeze"]).decode().splitlines()
             )
             airflow_provider_packages = [
                 package_line.split("=")[0]
                 for package_line in installed_packages
                 if package_line.startswith("apache-airflow-providers")
             ]
-            self.announce(
-                f'Uninstalling ${airflow_provider_packages}!', level=log.INFO)
-            subprocess.check_call(
-                ["python3", "-m", "pip", "uninstall", "--yes", *airflow_provider_packages])
+            self.announce(f'Uninstalling ${airflow_provider_packages}!', level=log.INFO)
+            subprocess.check_call(["python3", "-m", "pip", "uninstall", "--yes", *airflow_provider_packages])
         except subprocess.CalledProcessError as e:
-            self.announce(
-                f'Error when uninstalling airflow provider packages: {e}!', level=log.WARN)
+            self.announce(f'Error when uninstalling airflow provider packages: {e}!', level=log.WARN)
         super().run()
 
 
@@ -1173,8 +1151,7 @@ class Install(install_orig):
     """Forces installation of providers from sources in editable mode."""
 
     def run(self) -> None:
-        self.announce(
-            'Standard installation. Providers are installed from packages', level=log.INFO)
+        self.announce('Standard installation. Providers are installed from packages', level=log.INFO)
         super().run()
 
 
@@ -1194,8 +1171,7 @@ def do_setup() -> None:
         The kwargs in setup() call override those that are specified in setup.cfg.
         """
         if os.getenv(INSTALL_PROVIDERS_FROM_SOURCES) == 'true':
-            setup_kwargs['packages'] = find_namespace_packages(include=[
-                                                               'airflow*'])
+            setup_kwargs['packages'] = find_namespace_packages(include=['airflow*'])
 
     include_provider_namespace_packages_when_installing_from_sources()
     if os.getenv(INSTALL_PROVIDERS_FROM_SOURCES) == 'true':

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ PY39 = sys.version_info >= (3, 9)
 
 logger = logging.getLogger(__name__)
 
-version = '2.3.4.post45'
+version = '2.3.4.post46'
 
 AIRFLOW_SOURCES_ROOT = Path(__file__).parent.resolve()
 my_dir = dirname(__file__)
@@ -54,7 +54,8 @@ my_dir = dirname(__file__)
 def airflow_test_suite() -> unittest.TestSuite:
     """Test suite for Airflow tests"""
     test_loader = unittest.TestLoader()
-    test_suite = test_loader.discover(os.path.join(my_dir, 'tests'), pattern='test_*.py')
+    test_suite = test_loader.discover(
+        os.path.join(my_dir, 'tests'), pattern='test_*.py')
     return test_suite
 
 
@@ -112,7 +113,8 @@ class CompileAssets(Command):
     def run(self) -> None:
         """Run a command to compile and build assets."""
         www_dir = AIRFLOW_SOURCES_ROOT / "airflow" / "www"
-        subprocess.check_call(['yarn', 'install', '--frozen-lockfile'], cwd=str(www_dir))
+        subprocess.check_call(
+            ['yarn', 'install', '--frozen-lockfile'], cwd=str(www_dir))
         subprocess.check_call(['yarn', 'run', 'build'], cwd=str(www_dir))
 
 
@@ -155,10 +157,12 @@ def git_version(version_: str) -> str:
         try:
             repo = git.Repo(os.path.join(*[my_dir, '.git']))
         except git.NoSuchPathError:
-            logger.warning('.git directory not found: Cannot compute the git version')
+            logger.warning(
+                '.git directory not found: Cannot compute the git version')
             return ''
         except git.InvalidGitRepositoryError:
-            logger.warning('Invalid .git directory not found: Cannot compute the git version')
+            logger.warning(
+                'Invalid .git directory not found: Cannot compute the git version')
             return ''
     except ImportError:
         logger.warning('gitpython not found: Cannot compute the git version.')
@@ -232,7 +236,8 @@ azure = [
     'azure-mgmt-datalake-store>=0.5.0',
     'azure-mgmt-resource>=2.2.0',
     # limited due to https://github.com/Azure/azure-sdk-for-python/pull/18801  implementation released in 12.9
-    'azure-storage-blob',  # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations
+    # Temporarily remove >=12.7.0,<12.9.0 restriction for lyft-regulatoryintegrations
+    'azure-storage-blob',
     'azure-storage-common>=2.1.0',
     'azure-storage-file>=2.1.0',
     # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191
@@ -516,7 +521,8 @@ redis = [
     # TODO: upgrade to support redis package >=4
     'redis~=3.2',
 ]
-salesforce = ['simple-salesforce>=1.0.0', 'tableauserverclient', pandas_requirement]
+salesforce = ['simple-salesforce>=1.0.0',
+              'tableauserverclient', pandas_requirement]
 samba = [
     'smbprotocol>=1.5.0',
 ]
@@ -663,7 +669,8 @@ devel_only = [
     'yamllint',
 ]
 
-devel = cgroups + devel_only + doc + kubernetes + mypy_dependencies + mysql + pandas + password
+devel = cgroups + devel_only + doc + kubernetes + \
+    mypy_dependencies + mysql + pandas + password
 devel_hadoop = devel + hdfs + hive + kerberos + presto + webhdfs
 
 # Dict of all providers which are part of the Apache Airflow repository together with their requirements
@@ -760,7 +767,8 @@ CORE_EXTRAS_REQUIREMENTS: Dict[str, List[str]] = {
     'async': async_packages,
     'celery': celery,  # also has provider, but it extends the core with the CeleryExecutor
     'cgroups': cgroups,
-    'cncf.kubernetes': kubernetes,  # also has provider, but it extends the core with the KubernetesExecutor
+    # also has provider, but it extends the core with the KubernetesExecutor
+    'cncf.kubernetes': kubernetes,
     'dask': dask,
     'deprecated_api': deprecated_api,
     'github_enterprise': flask_appbuilder_oauth,
@@ -840,7 +848,8 @@ def add_extras_for_all_deprecated_aliases() -> None:
     for alias, extra in EXTRAS_DEPRECATED_ALIASES.items():
         requirements = EXTRAS_REQUIREMENTS.get(extra) if extra != '' else []
         if requirements is None:
-            raise Exception(f"The extra {extra} is missing for deprecated alias {alias}")
+            raise Exception(
+                f"The extra {extra} is missing for deprecated alias {alias}")
         EXTRAS_REQUIREMENTS[alias] = requirements
 
 
@@ -891,11 +900,13 @@ ALL_DB_PROVIDERS = [
 ]
 
 # Special requirements for all database-related providers. They are de-duplicated.
-all_dbs = list({req for db_provider in ALL_DB_PROVIDERS for req in PROVIDERS_REQUIREMENTS[db_provider]})
+all_dbs = list(
+    {req for db_provider in ALL_DB_PROVIDERS for req in PROVIDERS_REQUIREMENTS[db_provider]})
 
 # Requirements for all "user" extras (no devel). They are de-duplicated. Note that we do not need
 # to separately add providers requirements - they have been already added as 'providers' extras above
-_all_requirements = list({req for extras_reqs in EXTRAS_REQUIREMENTS.values() for req in extras_reqs})
+_all_requirements = list(
+    {req for extras_reqs in EXTRAS_REQUIREMENTS.values() for req in extras_reqs})
 
 # All user extras here
 EXTRAS_REQUIREMENTS["all"] = _all_requirements
@@ -955,7 +966,8 @@ devel_ci = devel_all
 # They can be use to install some predefined set of dependencies.
 EXTRAS_REQUIREMENTS["doc"] = doc
 EXTRAS_REQUIREMENTS["devel"] = devel  # devel already includes doc
-EXTRAS_REQUIREMENTS["devel_hadoop"] = devel_hadoop  # devel_hadoop already includes devel
+# devel_hadoop already includes devel
+EXTRAS_REQUIREMENTS["devel_hadoop"] = devel_hadoop
 EXTRAS_REQUIREMENTS["devel_all"] = devel_all
 EXTRAS_REQUIREMENTS["devel_ci"] = devel_ci
 
@@ -1030,13 +1042,16 @@ class AirflowDistribution(Distribution):
             self.install_requires = [
                 req for req in self.install_requires if not req.startswith('apache-airflow-providers-')
             ]
-            provider_yaml_files = glob.glob("airflow/providers/**/provider.yaml", recursive=True)
+            provider_yaml_files = glob.glob(
+                "airflow/providers/**/provider.yaml", recursive=True)
             for provider_yaml_file in provider_yaml_files:
-                provider_relative_path = relpath(provider_yaml_file, os.path.join(my_dir, "airflow"))
+                provider_relative_path = relpath(
+                    provider_yaml_file, os.path.join(my_dir, "airflow"))
                 self.package_data['airflow'].append(provider_relative_path)
         else:
             self.install_requires.extend(
-                [get_provider_package_from_package_id(package_id) for package_id in PREINSTALLED_PROVIDERS]
+                [get_provider_package_from_package_id(
+                    package_id) for package_id in PREINSTALLED_PROVIDERS]
             )
 
 
@@ -1079,7 +1094,8 @@ def replace_extra_requirement_with_provider_packages(extra: str, providers: List
     """
     if extra in ['cncf.kubernetes', 'kubernetes', 'celery']:
         EXTRAS_REQUIREMENTS[extra].extend(
-            [get_provider_package_from_package_id(package_name) for package_name in providers]
+            [get_provider_package_from_package_id(
+                package_name) for package_name in providers]
         )
     else:
         EXTRAS_REQUIREMENTS[extra] = [
@@ -1097,7 +1113,8 @@ def add_provider_packages_to_extra_requirements(extra: str, providers: List[str]
     :param providers: list of provider ids
     """
     EXTRAS_REQUIREMENTS[extra].extend(
-        [get_provider_package_from_package_id(package_name) for package_name in providers]
+        [get_provider_package_from_package_id(
+            package_name) for package_name in providers]
     )
 
 
@@ -1127,23 +1144,28 @@ class Develop(develop_orig):
     """Forces removal of providers in editable mode."""
 
     def run(self) -> None:  # type: ignore
-        self.announce('Installing in editable mode. Uninstalling provider packages!', level=log.INFO)
+        self.announce(
+            'Installing in editable mode. Uninstalling provider packages!', level=log.INFO)
         # We need to run "python3 -m pip" because it might be that older PIP binary is in the path
         # And it results with an error when running pip directly (cannot import pip module)
         # also PIP does not have a stable API so we have to run subprocesses ¯\_(ツ)_/¯
         try:
             installed_packages = (
-                subprocess.check_output(["python3", "-m", "pip", "freeze"]).decode().splitlines()
+                subprocess.check_output(
+                    ["python3", "-m", "pip", "freeze"]).decode().splitlines()
             )
             airflow_provider_packages = [
                 package_line.split("=")[0]
                 for package_line in installed_packages
                 if package_line.startswith("apache-airflow-providers")
             ]
-            self.announce(f'Uninstalling ${airflow_provider_packages}!', level=log.INFO)
-            subprocess.check_call(["python3", "-m", "pip", "uninstall", "--yes", *airflow_provider_packages])
+            self.announce(
+                f'Uninstalling ${airflow_provider_packages}!', level=log.INFO)
+            subprocess.check_call(
+                ["python3", "-m", "pip", "uninstall", "--yes", *airflow_provider_packages])
         except subprocess.CalledProcessError as e:
-            self.announce(f'Error when uninstalling airflow provider packages: {e}!', level=log.WARN)
+            self.announce(
+                f'Error when uninstalling airflow provider packages: {e}!', level=log.WARN)
         super().run()
 
 
@@ -1151,7 +1173,8 @@ class Install(install_orig):
     """Forces installation of providers from sources in editable mode."""
 
     def run(self) -> None:
-        self.announce('Standard installation. Providers are installed from packages', level=log.INFO)
+        self.announce(
+            'Standard installation. Providers are installed from packages', level=log.INFO)
         super().run()
 
 
@@ -1171,7 +1194,8 @@ def do_setup() -> None:
         The kwargs in setup() call override those that are specified in setup.cfg.
         """
         if os.getenv(INSTALL_PROVIDERS_FROM_SOURCES) == 'true':
-            setup_kwargs['packages'] = find_namespace_packages(include=['airflow*'])
+            setup_kwargs['packages'] = find_namespace_packages(include=[
+                                                               'airflow*'])
 
     include_provider_namespace_packages_when_installing_from_sources()
     if os.getenv(INSTALL_PROVIDERS_FROM_SOURCES) == 'true':


### PR DESCRIPTION
Hardcode cluster_id to the default Airflow 2 value because we are only running 1 cluster in house.

This is currently only returning 999 anyway (the cluster_name is airflowinfra2): https://sourcegraph.lyft.net/github.com/lyft/airflowinfra2/-/blob/airflowinfra/multi_cluster_utils.py?L47

This should have no impact since no functionality is being changed, but will test this on staging before deploying to prod.
